### PR TITLE
cant open mdt when dead

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -50,8 +50,14 @@ end)
 RegisterKeyMapping('mdt', 'Open Police MDT', 'keyboard', 'k')
 
 RegisterCommand('mdt', function()
-    if GetJobType(PlayerData.job.name) ~= nil then
-        TriggerServerEvent('mdt:server:openMDT')
+    local plyPed = PlayerPedId()
+    PlayerData = QBCore.Functions.GetPlayerData()
+    if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() then
+        if GetJobType(PlayerData.job.name) ~= nil then
+            TriggerServerEvent('mdt:server:openMDT')
+        end
+    else
+        QBCore.Functions.Notify("Can't do that!", "error")
     end
 end, false)
 


### PR DESCRIPTION
- added function so the player cant open the mdt when dead, inlaststand, handcuffed or when pause menu is active