### PR TITLE
fix: Empty Profile Data Error Handling

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -284,7 +284,7 @@ QBCore.Functions.CreateCallback('mdt:server:GetProfileData', function(source, cb
 	local mdtData2 = GetPfpFingerPrintInformation(sentId)
 	if mdtData2 then
 		person.fingerprint = mdtData2.fingerprint
-		person.profilepic = mdtData.pfp
+		person.profilepic = mdtData and mdtData.pfp or ""
 	end
 
 	return cb(person)


### PR DESCRIPTION
When you save a citizens profile without editing any data you wont be able to reopen their profile because of this error. It ended up being resolved after the following change.