### PR TITLE
ps-dispatch check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For all support questions, ask in our Discord support chat. Do not create issues
 
 - QBCore
 - OxMySQL V1.9.0 (will release docs on how to use an older version)
+- Ps-Dispatch https://github.com/Project-Sloth/ps-dispatch
 
 ## EchoRP MDT QBCore Edit (WIP)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -60,6 +60,10 @@ end)
 RegisterKeyMapping('mdt', 'Open Police MDT', 'keyboard', 'k')
 
 RegisterCommand('mdt', function()
+    if GetResourceState("ps-dispatch") ~= "started" then -- Checking if the resource is loaded, preventing errors server side 
+        QBCore.Functions.Notify("ps-dispatch didn't load correctly", "error")
+        return
+    end
     local plyPed = PlayerPedId()
     PlayerData = QBCore.Functions.GetPlayerData()
     if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() then

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -19,7 +19,9 @@ client_scripts{
     'client/main.lua',
     'client/cl_impound.lua'
 } 
-
+dependency {
+    "ps-dispatch"
+    }
 ui_page 'ui/dashboard.html'
 
 files {


### PR DESCRIPTION
this will add the ps-dispatch as a dependency and will not load the mdt if the resource is not present, and if for some reason the resource is there and not loaded will show an error to the user.