### PR TITLE
fix(profiles): Profiles missing license data

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -205,6 +205,13 @@ QBCore.Functions.CreateCallback('mdt:server:GetProfileData', function(source, cb
 	if type(target.charinfo) == 'string' then target.charinfo = json.decode(target.charinfo) end
 	if type(target.metadata) == 'string' then target.metadata = json.decode(target.metadata) end
 
+	local licencesdata = target.metadata['licences'] or {
+        ['driver'] = false,
+        ['business'] = false,
+        ['weapon'] = false,
+		['pilot'] = false
+	}
+
 	local job, grade = UnpackJob(target.job)
 
 	local person = {
@@ -214,7 +221,7 @@ QBCore.Functions.CreateCallback('mdt:server:GetProfileData', function(source, cb
 		job = job.label,
 		grade = grade.name,
 		pp = ProfPic(target.charinfo.gender),
-		licences = target.metadata['licences'],
+		licences = licencesdata,,
 		dob = target.charinfo.birthdate,
 		mdtinfo = '',
 		fingerprint = '',

--- a/ui/app.js
+++ b/ui/app.js
@@ -198,10 +198,15 @@ $(document).ready(() => {
     // convert key value pair object of licenses to array
     let licenses = Object.entries(result.licences);
 
+    if (licenses.length == 0 || licenses.length == undefined) {
+      var licenseTypes = ['business', 'pilot', 'weapon', 'driver'];
+      licenses = Object.entries(licenseTypes.reduce((licenseType, licenseValue) => (licenseType[licenseValue] = false, licenseType), {}));
+    }
+
     if (licenses.length > 0 && (PoliceJobs[playerJob] !== undefined || DojJobs[playerJob] !== undefined)) {
         licencesHTML = '';
         for (const [lic, hasLic] of licenses) {
-  
+
           let tagColour = hasLic == true ? "green-tag" : "red-tag";
           licencesHTML += `<span class="license-tag ${tagColour} ${lic}" data-type="${lic}">${titleCase(lic)}</span>`;
         }
@@ -307,7 +312,7 @@ $(document).ready(() => {
                 <div class="bulletin-item-title">${title}</div>
                 <div class="bulletin-item-info">${info}</div>
                 <div class="bulletin-bottom-info">
-                    
+
                     <div class="bulletin-date">${MyName} - ${timeAgo(
           Number(time.getTime())
         )}</div>
@@ -411,7 +416,7 @@ $(document).ready(() => {
         let tags = new Array();
         let gallery = new Array();
         let licenses = {};
-        
+
         $(".tags-holder")
           .find("div")
           .each(function () {
@@ -438,16 +443,16 @@ $(document).ready(() => {
         let description = $(".manage-profile-info").val();
         let fingerprint = $(".manage-profile-fingerprint").val();
         let id = $(".manage-profile-citizenid-input").val();
-        
+
         $(".licenses-holder")
         .find("span")
         .each(function(){
           let type = $(this).data("type")
           if ($(this).attr('class').includes('green-tag')){
-            licenses[type] = true
+            licenses[type] = true;
           }
           else{
-            licenses[type] = false
+            licenses[type] = false;
           }
         })
 
@@ -2574,7 +2579,7 @@ $(document).ready(() => {
           return true;
         }
         $(".dmv-items").empty();
-        
+
         let vehicleHTML = "";
 
         result.forEach((value) => {
@@ -2668,7 +2673,7 @@ $(document).ready(() => {
           } else {
             imageurl = newImageurl;
           }
-          
+
           let code5 = false;
           let code5tag = $(".vehicle-tags").find(".code5-tag");
           if (code5tag.hasClass("green-tag")) {
@@ -3839,7 +3844,7 @@ $(document).ready(() => {
                 </div>
                 </div>`);
       });
-      
+
       let policeCount = 0;
       let emsCount = 0;
       let dojCount = 0;
@@ -4077,15 +4082,15 @@ $(document).ready(() => {
         if (value["doorCount"]) {
           DispatchItem += `<div class="call-bottom-info"><span class="fas fa-door-open"></span>${value.doorCount}</div>`;
         }
-        
+
         if (value["speed"]) {
           DispatchItem += `<div class="call-bottom-info"><span class="fas fa-arrow-right"></span>${value.speed}</div>`;
         }
-        
+
         if (value["weapon"]) {
           DispatchItem += `<div class="call-bottom-info"><span class="fas fa-bullseye"></span>${value.weapon}</div>`;
         }
-        
+
         if (value["heading"]) {
           DispatchItem += `<div class="call-bottom-info"><span class="fas fa-share"></span>${value.heading}</div>`;
         }
@@ -4386,7 +4391,7 @@ $(document).ready(() => {
         );
         $(".manage-incidents-title").css("width", "95%");
       }
-      
+
       let associateddata = eventData.convictions;
       $.each(associateddata, function (index, value) {
         $(".associated-incidents-tags-holder").prepend(
@@ -4470,7 +4475,7 @@ $(document).ready(() => {
         $(".fine-recommended-amount")
           .filter("[data-id='" + value.cid + "']")
           .val(value.recfine);
-          
+
         $(".sentence-recommended-amount")
           .filter("[data-id='" + value.cid + "']")
           .val(value.recsentence);
@@ -4991,6 +4996,11 @@ function searchProfilesResults(result) {
     let licences = "";
     let licArr = Object.entries(value.licences);
 
+    if (licArr.length == 0 || licArr.length == undefined) {
+      var licenseTypes = ['business', 'pilot', 'weapon', 'driver'];
+      licArr = Object.entries(licenseTypes.reduce((licenseType, licenseValue) => (licenseType[licenseValue] = false, licenseType), {}));
+    }
+
     if (licArr.length > 0 && (PoliceJobs[playerJob] !== undefined || DojJobs[playerJob] !== undefined)) {
       for (const [lic, hasLic] of licArr) {
         let tagColour =
@@ -5011,7 +5021,7 @@ function searchProfilesResults(result) {
     ) {
       convictions = "orange-tag";
     }
-   
+
     if (value.pp == '') {
       value.pp = 'img/not-found.jpg'
     }


### PR DESCRIPTION
This is a dirty but functional fix to address missing licenses that breaks profiles (charges, history, unable to save, etc) when the license data is empty in the player's metadata.

It should always ensure at least something is in the licences field, so that if a profile breaks, it can be fixed by granting the user a new license without making database changes each time.

Tested in a dev server on offline player (for SQL), and logged in player (the licenses function changes depending if the user is logged in or not)

Fixes #59