### PR TITLE
Plate reader now checks for warrants and returns registered owner and report numbers

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -34,12 +34,11 @@ if Config.UseWolfknightRadar == true then
 		local warrant = GetWarrantStatus(plate)
 
 		if bolo == true then
-			TriggerClientEvent('QBCore:Notify', src, 'Plate: '..plate..' '..vehinfo., "error", 30000)
-			TriggerClientEvent('QBCore:Notify', src, 'Plate: '..plate..'HAS A BOLO', "error", 30000)
+			TriggerClientEvent('QBCore:Notify', src, 'Plate: '..plate..' - HAS A BOLO', "error", 45000)
 		end
 		print(warrant)
 		if warrant == true then
-			TriggerClientEvent('QBCore:Notify', src, 'Plate: '..plate..' OWNER WANTED', "error", 30000)
+			TriggerClientEvent('QBCore:Notify', src, 'Plate: '..plate..' - REGISTERED OWNER IS WANTED', "error", 45000)
 		end
 
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -31,12 +31,26 @@ if Config.UseWolfknightRadar == true then
 		local src = source
 		local Player = QBCore.Functions.GetPlayer(src)
 		local bolo = GetBoloStatus(plate)
-		print(cam, plate, index)
+		local warrant = GetWarrantStatus(plate)
+
 		if bolo == true then
-			TriggerClientEvent("wk:togglePlateLock", Player.PlayerData.source, cam, beep, bolo)
+			TriggerClientEvent('QBCore:Notify', src, 'Plate: '..plate..' '..vehinfo., "error", 30000)
+			TriggerClientEvent('QBCore:Notify', src, 'Plate: '..plate..'HAS A BOLO', "error", 30000)
 		end
+		print(warrant)
+		if warrant == true then
+			TriggerClientEvent('QBCore:Notify', src, 'Plate: '..plate..' OWNER WANTED', "error", 30000)
+		end
+
+
+		if bolo or warrant == true then
+		--print('Bolo or warrant is true')
+		TriggerClientEvent("wk:togglePlateLock", Player.PlayerData.source, cam, beep, bolo)
+		end
+
 	end)
 end
+
 RegisterNetEvent("ps-mdt:server:OnPlayerUnload", function()
 	--// Delete player from the MDT on logout
 	local src = source
@@ -1328,6 +1342,15 @@ function GetBoloStatus(plate)
 	return false
 end
 
+function GetWarrantStatus(plate)
+    local result = MySQL.query.await("SELECT p.plate, p. citizenid FROM player_vehicles p INNER JOIN mdt_convictions m ON p.citizenid = m.cid WHERE m.warrant =1 AND p.plate =?", {plate})
+	if result and result[1] then
+		return true
+	end
+
+	return false
+end
+
 function GetVehicleInformation(plate)
 	local result = MySQL.query.await('SELECT * FROM mdt_vehicleinfo WHERE plate = @plate', {['@plate'] = plate})
     if result[1] then
@@ -1336,4 +1359,3 @@ function GetVehicleInformation(plate)
         return false
     end
 end
-

--- a/server/main.lua
+++ b/server/main.lua
@@ -44,7 +44,7 @@ if Config.UseWolfknightRadar == true then
 
 		if bolo or warrant == true then
 		--print('Bolo or warrant is true')
-		TriggerClientEvent("wk:togglePlateLock", Player.PlayerData.source, cam, beep, bolo)
+		TriggerClientEvent("wk:togglePlateLock", Player.PlayerData.source, cam, beep, 1)
 		end
 
 	end)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -16,6 +16,8 @@ To save on unnecessary database queries, in wk_wars2x/config.lua set 'CONFIG.use
 This will only check plates of vehicles that have been occupied by a player
 --]]
 
+Config.WolfknightNotifyTime = 5000 --How long the notification displays for in miliseconds (30000 = 30 seconds)
+
 Config.OnlyShowOnDuty = true
 
 Config.Fuel = "lj-fuel" -- "LegacyFuel", "lj-fuel"


### PR DESCRIPTION
Apologies for the messy 8x commits - Still a bit unfamiliar with github but I'm getting there.

Summary of changes:

1: Updated the plate scanner event "wk:onPlateScanned" in server/main.lua
2: Updated the GetBoloStatus function in server/main.lua to return the BOLO ID and title
3: Created GetWarrantStatus function in server/main.lua to return true/false, owner, and incident ID
4: Added Config.WolfknightNotifyTime = 5000 --How long the notification displays for in miliseconds (30000 = 30 seconds)

**Preview:**

https://www.youtube.com/watch?v=F4H-t9WPUhM&ab_channel=CaseyReed


**1 - Updated the plate scanner event "wk:onPlateScanned" in server/main.lua**

```
if Config.UseWolfknightRadar == true then
	RegisterNetEvent("wk:onPlateScanned")
	AddEventHandler("wk:onPlateScanned", function(cam, plate, index)
		local src = source
		local Player = QBCore.Functions.GetPlayer(src)
		local bolo, title, boloid = GetBoloStatus(plate, title, boloid)
		local warrant, owner, incidentid = GetWarrantStatus(plate, owner, incidentid)

		if bolo == true then
			TriggerClientEvent('QBCore:Notify', src, 'BOLO ID: '..boloid..' | Title: '..title..' | Registered Owner: '..owner..' | Plate: '..plate, 'error', Config.WolfknightNotifyTime)
		end
		if warrant == true then
			TriggerClientEvent('QBCore:Notify', src, 'WANTED - INCIDENT ID: '..incidentid..' | Registered Owner: '..owner..' | Plate: '..plate, 'error', Config.WolfknightNotifyTime)
		end


		if bolo or warrant == true then
		TriggerClientEvent("wk:togglePlateLock", src, cam, true, 1)
		end

	end)
end
```

```
**2: Updated the GetBoloStatus function in server/main.lua to return the BOLO ID and title **

function GetBoloStatus(plate, title, boloid)
    local result = MySQL.query.await("SELECT * FROM mdt_bolos where plate = @plate", {['@plate'] = plate})
	if result and result[1] then
		local title = result[1]['title']
		local boloid = result[1]['id']
		return true, title, boloid
	end

	return false
end
```

**3: Created GetWarrantStatus function in server/main.lua to return true/false, owner, and incident ID**

```
function GetWarrantStatus(plate, owner, incidentid)
    local result = MySQL.query.await("SELECT p.plate, p.citizenid, m.id FROM player_vehicles p INNER JOIN mdt_convictions m ON p.citizenid = m.cid WHERE m.warrant =1 AND p.plate =?", {plate})
	if result and result[1] then
		local citizenid = result[1]['citizenid']
		local Player = QBCore.Functions.GetPlayerByCitizenId(citizenid)
		local owner = Player.PlayerData.charinfo.firstname.." "..Player.PlayerData.charinfo.lastname
		local incidentid = result[1]['id']
		return true, owner, incidentid
	end
	return false
end
```


