### PR TITLE
Add an incidents section to the profile page

### DIFF
--- a/server/dbm.lua
+++ b/server/dbm.lua
@@ -44,10 +44,10 @@ function GetPfpFingerPrintInformation(cid)
 	return result[1]
 end
 
--- idk but I guess sure?
 function GetIncidentName(id)
 	-- Should also be a scalar
-	return MySQL.query.await('SELECT title FROM `mdt_incidents` WHERE id = :id LIMIT 1', { id = id })
+	local result = MySQL.query.await('SELECT title FROM `mdt_incidents` WHERE id = :id LIMIT 1', { id = id })
+    return result[1]
 	-- return exports.oxmysql:executeSync('SELECT title FROM `mdt_incidents` WHERE id = :id LIMIT 1', { id = id })
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -258,11 +258,22 @@ QBCore.Functions.CreateCallback('mdt:server:GetProfileData', function(source, cb
 
 	if Config.PoliceJobs[JobName] or Config.DojJobs[JobName] then
 		local convictions = GetConvictions({person.cid})
+		local incidents = {}
 		person.convictions2 = {}
 		local convCount = 1
 		if next(convictions) then
 			for _, conv in pairs(convictions) do
 				if conv.warrant then person.warrant = true end
+
+				-- Get the incident details
+				local id = conv.linkedincident
+				local incident = GetIncidentName(id)
+				incidents[#incidents + 1] = {
+					id = id,
+					title = incident.title,
+					time = conv.time
+				}
+
 				local charges = json.decode(conv.charges)
 				for _, charge in pairs(charges) do
 					person.convictions2[convCount] = charge
@@ -270,6 +281,9 @@ QBCore.Functions.CreateCallback('mdt:server:GetProfileData', function(source, cb
 				end
 			end
 		end
+
+		person.incidents = incidents
+
 		local hash = {}
 		person.convictions = {}
 
@@ -279,6 +293,7 @@ QBCore.Functions.CreateCallback('mdt:server:GetProfileData', function(source, cb
 				hash[v] = true
 			end
 		end
+
 		local vehicles = GetPlayerVehicles(person.cid)
 
 		if vehicles then

--- a/ui/app.js
+++ b/ui/app.js
@@ -194,17 +194,19 @@ $(document).ready(() => {
     $(".manage-profile-fingerprint").removeAttr("disabled");
     $(".manage-profile-pic").attr("src", result["profilepic"] ?? "img/male.png");
 
-    const { vehicles, tags, gallery, convictions, properties } = result
+    const { vehicles, tags, gallery, convictions, incidents, properties } = result
 
     $(".licenses-holder").empty();
     $(".tags-holder").empty();
     $(".vehs-holder").empty();
     $(".gallery-inner-container").empty();
     $(".convictions-holder").empty();
+    $(".profile-incidents-holder").empty();
 
     let licencesHTML = '<div style="color: #fff; text-align:center;">No Licenses</div>';
     let tagsHTML = '<div style="color: #fff; text-align:center;">No Tags</div>';
-    let convHTML = '<div style="color: #fff; text-align:center;">Clean Record ?</div>';
+    let convHTML = '<div style="color: #fff; text-align:center;">Clean Record</div>';
+    let incidentsHTML = '<div style="color: #fff; text-align:center;">No Incidents</div>';
     let vehHTML = '<div style="color: #fff; text-align:center;">No Vehicles</div>';
     let galleryHTML = '<div style="color: #fff; text-align:center;">No Photos</div>';
     let propertyHTML = '<div style="color: #fff; text-align:center;">No Properties</div>';
@@ -218,25 +220,43 @@ $(document).ready(() => {
     }
 
     if (licenses.length > 0 && (PoliceJobs[playerJob] !== undefined || DojJobs[playerJob] !== undefined)) {
-        licencesHTML = '';
-        for (const [lic, hasLic] of licenses) {
+      licencesHTML = '';
+      for (const [lic, hasLic] of licenses) {
+        let tagColour = hasLic == true ? "green-tag" : "red-tag";
+        licencesHTML += `<span class="license-tag ${tagColour} ${lic}" data-type="${lic}">${titleCase(lic)}</span>`;
+      }
 
-          let tagColour = hasLic == true ? "green-tag" : "red-tag";
-          licencesHTML += `<span class="license-tag ${tagColour} ${lic}" data-type="${lic}">${titleCase(lic)}</span>`;
-        }
       if (vehicles && vehicles.length > 0) {
-
         vehHTML = '';
         vehicles.forEach(value => {
           vehHTML += `<div class="veh-tag" data-plate="${value.plate}">${value.plate} - ${value.model} </div>`
         })
       }
+
       if (convictions && convictions.length > 0) {
         convHTML = '';
         convictions.forEach(value => {
           convHTML += `<div class="white-tag">${value} </div>`;
         })
       }
+
+      if (incidents && incidents.length > 0) {
+        incidentsHTML='';
+        // Sort incidents so most recent appear first
+        const sortedIncidents = incidents.sort((a,b) => b.time - a.time);
+        sortedIncidents.forEach(value => {
+          incidentsHTML += `<div class="white-tag" data-id=${value.id}>
+            <div style="display: flex">
+              <div class="incident-number">${value.id}</div>
+              <div>
+                ${value.title}
+                <div class="incident-timestamp">${getFormattedDate(new Date(Number(value.time)))}</div>
+              </div>
+            </div>
+          </div>`
+        })
+      }
+
       if (properties && properties.length > 0) {
         propertyHTML = '';
         properties.forEach(value => {
@@ -244,6 +264,7 @@ $(document).ready(() => {
         })
       }
     }
+
     if (tags && tags.length > 0) {
       tagsHTML = '';
       tags.forEach((tag) => {
@@ -271,6 +292,7 @@ $(document).ready(() => {
     $(".licenses-holder").html(licencesHTML);
     $(".tags-holder").html(tagsHTML);
     $(".convictions-holder").html(convHTML);
+    $(".profile-incidents-holder").html(incidentsHTML);
     $(".vehs-holder").html(vehHTML);
     $(".gallery-inner-container").html(galleryHTML);
     $(".houses-holder").html(propertyHTML);
@@ -2115,6 +2137,20 @@ $(document).ready(() => {
     ];
     openContextMenu(e, args);
   });
+
+  $(".profile-incidents-holder").on("contextmenu", ".white-tag", function (e) {
+    const args = [
+      {
+        className: "view-incident",
+        icon: "fas fa-search",
+        text: "View Incident",
+        info: $(this).data("id"),
+        status: "",
+      },
+    ];
+    openContextMenu(e, args);
+  });
+
   $(".reports-search-title").click(function () {
     if (canSearchReports == true) {
       if ($(".reports-search-input").css("display") == "none") {
@@ -4015,6 +4051,7 @@ $(document).ready(() => {
         if (PoliceJobs[playerJob] !== undefined || DojJobs[playerJob] !== undefined) {
           $(".manage-profile-licenses-container").removeClass("display_hidden");
           $(".manage-convictions-container").removeClass("display_hidden");
+          $(".manage-profile-incidents-container").removeClass("display_hidden");
           $(".manage-profile-vehs-container").removeClass("display_hidden");
           $(".manage-profile-houses-container").removeClass("display_hidden");
         }

--- a/ui/dashboard.html
+++ b/ui/dashboard.html
@@ -317,13 +317,15 @@
                     <div class="gallery-inner-container"></div>
                 </div>
 
-                <!-- Flakey, I need you to do the linked reports HTML/CSS for me. -->
-
                 <div class="manage-convictions-container display_hidden">
                     <div class="convictions-title">Known Convictions</div>
                     <div class="convictions-holder"></div>
                 </div>
 
+                <div class="manage-profile-incidents-container display_hidden">
+                    <div class="profile-incidents-title">Incidents</div>
+                    <div class="profile-incidents-holder"></div>
+                </div>
             </div>
         </div>
     </div>

--- a/ui/style.css
+++ b/ui/style.css
@@ -1571,6 +1571,51 @@ span.tag-input[contenteditable]:empty::before {
     user-select: none;
 }
 
+.manage-profile-incidents-container {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--color-1);
+    width: 100%;
+    border: 2px solid var(--color-3);
+    margin-top: 10px;
+    max-height: 200px;
+    overflow: scroll;
+}
+
+.profile-incidents-title {
+    background-color: var(--color-4);
+    color: white;
+    font-size: 18px;
+    font-weight: bolder;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    text-align: center;
+    margin: auto;
+    margin-top: 10px;
+    margin-bottom: 0px;
+    width: 95%;
+    align-items: center;
+    user-select: none;
+}
+
+.profile-incidents-holder {
+    overflow: auto;
+    margin: auto;
+    margin-top: 10px;
+    width: 95%;
+    user-select: none;
+}
+
+.incident-number {
+    padding-right: 8px;
+}
+
+.incident-timestamp {
+    color: #303030;
+    font-size: 10px;
+    font-weight: 500;
+}
+
 .loader {
     position: absolute;
     left: 50%;


### PR DESCRIPTION
# Overview
This PR adds an incidents section to the profile page, displaying a list of incidents in chronological order (most recent first), that this person has been invovled in.

You can right click the incident and then click View Incident, which will load the incident page.

# Details
- Update GetProfileData to also return the list of incidents
- As we are going through each conviction, we call `GetIncidentName` to get the title of the incident, and add it to the list.
- The UI sorts and renders each incident. Displaying the incident number, incident title, and date incident was created.

# UI
![image](https://user-images.githubusercontent.com/18689469/221435389-c49bd290-c315-43cf-9ab0-15396c7e9372.png)

![mdt-profile-incidents](https://user-images.githubusercontent.com/18689469/221435533-bd1034c8-d4a3-4069-b87b-f3365689e14a.gif)
