### PR TITLE
Add Jail, Fine, and Community Service buttons to the incidents page

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -359,6 +359,12 @@ RegisterNUICallback("updateLicence", function(data, cb)
     cb(true)
 end)
 
+--====================================================================================
+------------------------------------------
+--             INCIDENTS PAGE             --
+------------------------------------------
+--====================================================================================
+
 RegisterNUICallback("searchIncidents", function(data, cb)
     local incident = data.incident
     TriggerServerEvent('mdt:server:searchIncidents', incident)
@@ -375,6 +381,64 @@ RegisterNUICallback("incidentSearchPerson", function(data, cb)
     local name = data.name
     TriggerServerEvent('mdt:server:incidentSearchPerson', name )
     cb(true)
+end)
+
+-- Handle sending the player to jail
+-- Uses QB-Core/qb-policejob function to send the player to jail
+-- If you use a different jail system, you will need to change this
+RegisterNUICallback("sendToJail", function(data, cb)
+    local citizenId, sentence = data.citizenId, data.sentence
+
+    -- Gets the player id from the citizenId
+    local p = promise.new()
+    QBCore.Functions.TriggerCallback('mdt:server:GetPlayerSourceId', function(result)
+        p:resolve(result)
+    end, citizenId)
+
+    local targetSourceId = Citizen.Await(p)
+
+    if sentence > 0 then
+        -- Uses qb-policejob JailPlayer event
+        TriggerServerEvent("police:server:JailPlayer", targetSourceId, sentence)
+    end
+end)
+
+-- Handle sending a fine to a player
+-- Uses the QB-Core bill command to send a fine to a player
+-- If you use a different fine system, you will need to change this
+RegisterNUICallback("sendFine", function(data, cb)
+    local citizenId, fine = data.citizenId, data.fine
+    
+    -- Gets the player id from the citizenId
+    local p = promise.new()
+    QBCore.Functions.TriggerCallback('mdt:server:GetPlayerSourceId', function(result)
+        p:resolve(result)
+    end, citizenId)
+
+    local targetSourceId = Citizen.Await(p)
+
+    if fine > 0 then
+        -- Uses QB-Core /bill command
+        ExecuteCommand(('bill %s %s'):format(targetSourceId, fine))
+    end
+end)
+
+-- Handle sending the player to community service
+-- If you use a different community service system, you will need to change this
+RegisterNUICallback("sendToCommunityService", function(data, cb)
+    local citizenId, sentence = data.citizenId, data.sentence
+
+    -- Gets the player id from the citizenId
+    local p = promise.new()
+    QBCore.Functions.TriggerCallback('mdt:server:GetPlayerSourceId', function(result)
+        p:resolve(result)
+    end, citizenId)
+
+    local targetSourceId = Citizen.Await(p)
+
+    if sentence > 0 then
+        TriggerServerEvent("qb-communityservice:server:StartCommunityService", targetSourceId, sentence)
+    end
 end)
 
 RegisterNetEvent('mdt:client:getProfileData', function(sentData, isLimited)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1467,3 +1467,11 @@ function GetVehicleInformation(plate)
     end
 end
 
+-- Returns the source for the given citizenId
+QBCore.Functions.CreateCallback('mdt:server:GetPlayerSourceId', function(source, cb, targetCitizenId)
+	local targetPlayer = QBCore.Functions.GetPlayerByCitizenId(targetCitizenId)
+	local targetSource = targetPlayer.PlayerData.source
+	
+	cb(targetSource)
+end)
+

--- a/ui/app.js
+++ b/ui/app.js
@@ -23,6 +23,8 @@ var LastName = "";
 var DispatchNum = 0;
 var playerJob = "";
 let rosterLink  = "";
+//Set this to false if you don't want to show the send to community service button on the incidents page
+const canSendToCommunityService = true
 
 let impoundChanged = false;
 
@@ -1886,6 +1888,9 @@ $(document).ready(() => {
           $(".associated-incidents-sentence-input")
             .filter(`[data-id="${$(this).data("id")}"]`)
             .css("display", "none");
+          $(".associated-incidents-controls")
+            .filter(`[data-id="${$(this).data("id")}"]`)
+            .css("display", "none");
         }
       } else {
         $(this).removeClass("green-tag");
@@ -1903,10 +1908,38 @@ $(document).ready(() => {
           $(".associated-incidents-sentence-input")
             .filter(`[data-id="${$(this).data("id")}"]`)
             .fadeIn(100);
+          $(".associated-incidents-controls")
+            .filter(`[data-id="${$(this).data("id")}"]`)
+            .fadeIn(100);
         }
       }
     }
   );
+
+  $('.incidents-ghost-holder').on('click', '#jail-button', function() {
+    // Get the current sentence and recommended sentence values
+    const citizenId = $(this).data("id");
+    const sentence = $(".sentence-amount").filter(`[data-id=${citizenId}]`).val();
+    const recommendSentence = $(".sentence-recommended-amount").filter(`[data-id=${citizenId}]`).val();
+    sendToJail(citizenId, sentence, recommendSentence);
+  });
+
+  $('.incidents-ghost-holder').on('click', '#fine-button', function() {
+    // Get the current fine and recommended fine values
+    const citizenId = $(this).data("id");
+    const fine = $(".fine-amount").filter(`[data-id=${citizenId}]`).val();
+    const recommendFine = $(".fine-recommended-amount").filter(`[data-id=${citizenId}]`).val();
+    sendFine(citizenId, fine, recommendFine);
+  });
+
+  $('.incidents-ghost-holder').on('click', '#community-service-button', function() {
+    // Get the current sentence and recommended sentence values
+    const citizenId = $(this).data("id");
+    const sentence = $(".sentence-amount").filter(`[data-id=${citizenId}]`).val();
+    const recommendSentence = $(".sentence-recommended-amount").filter(`[data-id=${citizenId}]`).val();
+    sendToCommunityService(citizenId, sentence, recommendSentence);
+  });
+
   $(".contextmenu").on(
     "click",
     ".associated-incidents-remove-tag",
@@ -1961,74 +1994,33 @@ $(document).ready(() => {
         )}">${$(this).data("name")}</div>`
       );
 
+      // This section handles populating the fields when you add a new associated user to the incident
       $(".incidents-ghost-holder").prepend(
         `
-            <div class="associated-incidents-user-container" data-id="${$(
-          this
-        ).data("cid")}">
-                <div class="associated-incidents-user-title">${$(this).data(
-          "info"
-        )}</div>
+            <div class="associated-incidents-user-container" data-id="${$(this).data("cid")}">
+                <div class="associated-incidents-user-title">${$(this).data("info")}</div>
                 <div class="associated-incidents-user-tags-holder">
-                    <div class="associated-incidents-user-tag red-tag" data-id="${$(
-          this
-        ).data("cid")}">Warrant</div>
-                    <div class="associated-incidents-user-tag red-tag" data-id="${$(
-          this
-        ).data("cid")}">Guilty</div>
-                    <div class="associated-incidents-user-tag red-tag" data-id="${$(
-          this
-        ).data("cid")}">Processed</div>
-                    <div class="associated-incidents-user-tag red-tag" data-id="${$(
-          this
-        ).data("cid")}">Associated</div>
+                    <div class="associated-incidents-user-tag red-tag" data-id="${$(this).data("cid")}">Warrant</div>
+                    <div class="associated-incidents-user-tag red-tag" data-id="${$(this).data("cid")}">Guilty</div>
+                    <div class="associated-incidents-user-tag red-tag" data-id="${$(this).data("cid")}">Processed</div>
+                    <div class="associated-incidents-user-tag red-tag" data-id="${$(this).data("cid")}">Associated</div>
                 </div>
-                <div class="associated-incidents-user-holder" data-name="${$(
-          this
-        ).data("cid")}">
+                <div class="associated-incidents-user-holder" data-name="${$(this).data("cid")}"></div>
+                <div class="manage-incidents-title-tag" data-id="${$(this).data("cid")}">Recommended Fine</div>
+                <div class="associated-incidents-fine-input" data-id="${$(this).data("cid")}"><img src="img/h7S5f9J.webp"> <input disabled placeholder="0" class="fine-recommended-amount" id="fine-recommended-amount" data-id="${$(this).data("cid")}" type="number"></div>
+                <div class="manage-incidents-title-tag" data-id="${$(this).data("cid")}">Recommended Sentence</div>
+                <div class="associated-incidents-sentence-input" data-id="${$(this).data("cid")}"><img src="img/9Xn6xXK.webp"> <input disabled placeholder="0" class="sentence-recommended-amount" id="sentence-recommended-amount" data-id="${$(this).data("cid")}" type="number"></div>
+                <div class="manage-incidents-title-tag" data-id="${$(this).data("cid")}">Fine</div>
+                <div class="associated-incidents-fine-input" data-id="${$(this).data("cid")}"><img src="img/h7S5f9J.webp"> <input placeholder="Enter fine here..." value="0" class="fine-amount" data-id="${$(this).data("cid")}" type="number"></div>
+                <div class="manage-incidents-title-tag" data-id="${$(this).data("cid")}">Sentence</div>
+                <div class="associated-incidents-sentence-input" data-id="${$(this).data("cid")}"><img src="img/9Xn6xXK.webp"> <input placeholder="Enter months here..." value="0" class="sentence-amount" data-id="${$(this).data("cid")}" type="number"></div>
+                <div class="associated-incidents-controls" data-id="${$(this).data("cid")}">
+                    <div id="jail-button" class="control-button" data-id="${$(this).data("cid")}"><span class="fa-solid fa-building-columns" style="margin-top: 3.5px;"></span> Jail</div>
+                    <div id="fine-button" class="control-button" data-id="${$(this).data("cid")}"><span class="fa-solid fa-file-invoice-dollar" style="margin-top: 3.5px;"></span> Fine</div>
+                    ${canSendToCommunityService ? `<div id="community-service-button" class="control-button" data-id="${$(this).data("cid")}"> <span class="fa-solid fa-person-digging" style="margin-top: 3.5px;"></span>Community Service</div>` : ''}
                 </div>
-                <div class="manage-incidents-title-tag" data-id="${$(this).data(
-          "cid"
-        )}">Recommended Fine</div>
-                <div class="associated-incidents-fine-input" data-id="${$(
-          this
-        ).data(
-          "cid"
-        )}"><img src="img/h7S5f9J.webp"> <input disabled placeholder="0" class="fine-recommended-amount" id="fine-recommended-amount" data-id="${$(
-          this
-        ).data("cid")}" type="number"></div>
-                <div class="manage-incidents-title-tag" data-id="${$(this).data(
-          "cid"
-        )}">Recommended Sentence</div>
-                <div class="associated-incidents-sentence-input" data-id="${$(
-          this
-        ).data(
-          "cid"
-        )}"><img src="img/9Xn6xXK.webp"> <input disabled placeholder="0" class="sentence-recommended-amount" id="sentence-recommended-amount" data-id="${$(
-          this
-        ).data("cid")}" type="number"></div>
-                <div class="manage-incidents-title-tag" data-id="${$(this).data(
-          "cid"
-        )}">Fine</div>
-                <div class="associated-incidents-fine-input" data-id="${$(
-          this
-        ).data(
-          "cid"
-        )}"><img src="img/h7S5f9J.webp"> <input placeholder="Enter fine here..." value="0" class="fine-amount" data-id="${$(
-          this
-        ).data("cid")}" type="number"></div>
-                <div class="manage-incidents-title-tag" data-id="${$(this).data(
-          "cid"
-        )}">Sentence</div>
-                <div class="associated-incidents-sentence-input" data-id="${$(
-          this
-        ).data(
-          "cid"
-        )}"><img src="img/9Xn6xXK.webp"> <input placeholder="Enter months here..." value="0" class="sentence-amount" data-id="${$(
-          this
-        ).data("cid")}" type="number"></div>
             </div>
-            `
+        `
       );
     }
   );
@@ -4693,51 +4685,36 @@ $(document).ready(() => {
 
         const cid = value.cid;
 
-        if (value.associated == 1) {
-          $(".incidents-ghost-holder").prepend(
-            `<div class="associated-incidents-user-container" data-id="${value.cid}">
-                            <div class="associated-incidents-user-title">${value.name} (#${value.cid})</div>
-                            <div class="associated-incidents-user-tags-holder">
-                                <div class="associated-incidents-user-tag ${warrantTag}" data-id="${value.cid}">Warrant</div>
-                                <div class="associated-incidents-user-tag ${guiltyTag}" data-id="${value.cid}">Guilty</div>
-                                <div class="associated-incidents-user-tag ${processedTag}" data-id="${value.cid}">Processed</div>
-                                <div class="associated-incidents-user-tag ${associatedTag}" data-id="${value.cid}">Associated</div>
-                            </div>
-                            <div class="associated-incidents-user-holder" data-name="${value.cid}" style="display:none;">
-                            </div>
-                            <div class="manage-incidents-title-tag" data-id="${value.cid}" style="display:none;">Recommended Fine</div>
-                            <div class="associated-incidents-fine-input" data-id="${value.cid}" style="display:none;"><img src="img/h7S5f9J.webp"> <input placeholder="0" disabled class="fine-recommended-amount" id="fine-recommended-amount" data-id="${value.cid}" type="number"></div>
-                            <div class="manage-incidents-title-tag" data-id="${value.cid}" style="display:none;">Recommended Sentence</div>
-                            <div class="associated-incidents-sentence-input" data-id="${value.cid}" style="display:none;"><img src="img/9Xn6xXK.webp"> <input placeholder="0" disabled class="sentence-recommended-amount" id="sentence-recommended-amount" data-id="${value.cid}" type="number"></div>
-                            <div class="manage-incidents-title-tag" data-id="${value.cid}" style="display:none;">Fine</div>
-                            <div class="associated-incidents-fine-input" data-id="${value.cid}" style="display:none;"><img src="img/h7S5f9J.webp"> <input placeholder="Enter fine here..." value="0" class="fine-amount" data-id="${value.cid}" type="number"></div>
-                            <div class="manage-incidents-title-tag" data-id="${value.cid}" style="display:none;">Sentence</div>
-                            <div class="associated-incidents-sentence-input" data-id="${value.cid}" style="display:none;"><img src="img/9Xn6xXK.webp"> <input placeholder="Enter months here..." value="0" class="sentence-amount" data-id="${value.cid}" type="number"></div>
-                        </div>`
-          );
-        } else {
-          $(".incidents-ghost-holder").prepend(
-            `<div class="associated-incidents-user-container" data-id="${value.cid}">
-                            <div class="associated-incidents-user-title">${value.name} (#${value.cid})</div>
-                            <div class="associated-incidents-user-tags-holder">
-                                <div class="associated-incidents-user-tag ${warrantTag}" data-id="${value.cid}">Warrant</div>
-                                <div class="associated-incidents-user-tag ${guiltyTag}" data-id="${value.cid}">Guilty</div>
-                                <div class="associated-incidents-user-tag ${processedTag}" data-id="${value.cid}">Processed</div>
-                                <div class="associated-incidents-user-tag ${associatedTag}" data-id="${value.cid}">Associated</div>
-                            </div>
-                            <div class="associated-incidents-user-holder" data-name="${value.cid}">
-                            </div>
-                            <div class="manage-incidents-title-tag" data-id="${value.cid}">Recommended Fine</div>
-                            <div class="associated-incidents-fine-input" data-id="${value.cid}"><img src="img/h7S5f9J.webp"> <input placeholder="0" disabled class="fine-recommended-amount" id="fine-recommended-amount" data-id="${value.cid}" type="number"></div>
-                            <div class="manage-incidents-title-tag" data-id="${value.cid}">Recommended Sentence</div>
-                            <div class="associated-incidents-sentence-input" data-id="${value.cid}"><img src="img/9Xn6xXK.webp"> <input placeholder="0" disabled class="sentence-recommended-amount" id="sentence-recommended-amount" data-id="${value.cid}" type="number"></div>
-                            <div class="manage-incidents-title-tag" data-id="${value.cid}">Fine</div>
-                            <div class="associated-incidents-fine-input" data-id="${value.cid}"><img src="img/h7S5f9J.webp"> <input placeholder="Enter fine here..." value="0" class="fine-amount" data-id="${value.cid}" type="number"></div>
-                            <div class="manage-incidents-title-tag" data-id="${value.cid}">Sentence</div>
-                            <div class="associated-incidents-sentence-input" data-id="${value.cid}"><img src="img/9Xn6xXK.webp"> <input placeholder="Enter months here..." value="0" class="sentence-amount" data-id="${value.cid}" type="number"></div>
-                        </div>`
-          );
-        }
+        // If the associated field is not checked, then populate the recommended fine and sentence fields
+        const associatedIncidentsContainer = (value.associated != 1) && `
+          <div class="associated-incidents-user-holder" data-name="${cid}" ></div>
+          <div class="manage-incidents-title-tag" data-id="${cid}">Recommended Fine</div>
+          <div class="associated-incidents-fine-input" data-id="${cid}"><img src="img/h7S5f9J.webp"> <input placeholder="0" disabled class="fine-recommended-amount" id="fine-recommended-amount" data-id="${cid}" type="number"></div>
+          <div class="manage-incidents-title-tag" data-id="${cid}">Recommended Sentence</div>
+          <div class="associated-incidents-sentence-input" data-id="${cid}"><img src="img/9Xn6xXK.webp"> <input placeholder="0" disabled class="sentence-recommended-amount" id="sentence-recommended-amount" data-id="${cid}" type="number"></div>
+          <div class="manage-incidents-title-tag" data-id="${cid}">Fine</div>
+          <div class="associated-incidents-fine-input" data-id="${cid}"><img src="img/h7S5f9J.webp"> <input placeholder="Enter fine here..." value="0" class="fine-amount" data-id="${cid}" type="number"></div>
+          <div class="manage-incidents-title-tag" data-id="${cid}">Sentence</div>
+          <div class="associated-incidents-sentence-input" data-id="${cid}"><img src="img/9Xn6xXK.webp"> <input placeholder="Enter months here..." value="0" class="sentence-amount" data-id="${cid}" type="number"></div>
+          <div class="associated-incidents-controls" data-id="${cid}">
+            <div id="jail-button" class="control-button" data-id="${cid}"><span class="fa-solid fa-building-columns" style="margin-top: 3.5px;"></span> Jail</div>
+            <div id="fine-button" class="control-button" data-id="${cid}"><span class="fa-solid fa-file-invoice-dollar" style="margin-top: 3.5px;"></span> Fine</div>
+            ${canSendToCommunityService ? `<div id="community-service-button" class="control-button" data-id="${cid}"> <span class="fa-solid fa-person-digging" style="margin-top: 3.5px;"></span>Community Service</div>` : ''}
+          </div>
+        `;
+
+        $(".incidents-ghost-holder").prepend(
+          `<div class="associated-incidents-user-container" data-id="${cid}">
+              <div class="associated-incidents-user-title">${value.name} (#${cid})</div>
+              <div class="associated-incidents-user-tags-holder">
+                  <div class="associated-incidents-user-tag ${warrantTag}" data-id="${cid}">Warrant</div>
+                  <div class="associated-incidents-user-tag ${guiltyTag}" data-id="${cid}">Guilty</div>
+                  <div class="associated-incidents-user-tag ${processedTag}" data-id="${cid}">Processed</div>
+                  <div class="associated-incidents-user-tag ${associatedTag}" data-id="${cid}">Associated</div>
+              </div>
+              ${associatedIncidentsContainer}
+          </div>`
+        );
 
         $(".fine-amount")
           .filter("[data-id='" + value.cid + "']")
@@ -5170,6 +5147,39 @@ function addTag(tagInput) {
       tag: tagInput,
     })
   );
+}
+
+// Use the customSentence if defined, otherwise use the recommendedSentence
+// This uses the assumption that customSentence will be 0 if not defined
+function sendToJail(citizenId, customSentence, recommendedSentence) {
+  const sentence = Number(customSentence) || Number(recommendedSentence);
+
+  $.post(`https://${GetParentResourceName()}/sendToJail`, JSON.stringify({
+    citizenId,
+    sentence,
+  }));
+}
+
+// Use the customSentence if defined, otherwise use the recommendedSentence
+// This uses the assumption that customSentence will be 0 if not defined
+function sendToCommunityService(citizenId, customSentence, recommendedSentence) {
+  const sentence = Number(customSentence) || Number(recommendedSentence);
+
+  $.post(`https://${GetParentResourceName()}/sendToCommunityService`, JSON.stringify({
+    citizenId,
+    sentence,
+  }));
+}
+
+// Use the customFine if defined, otherwise use the recommendedFine
+// This uses the assumption that customFine will be 0 if not defined
+function sendFine(citizenId, customFine, recommendedFine) {
+  const fine = Number(customFine) || Number(recommendedFine);
+
+  $.post(`https://${GetParentResourceName()}/sendFine`, JSON.stringify({
+    citizenId,
+    fine,
+  }));
 }
 
 // Context menu

--- a/ui/app.js
+++ b/ui/app.js
@@ -396,8 +396,8 @@ $(document).ready(() => {
     }
   });
   $(".associated-incidents-tags-add-btn").on("click", "", function () {
-    document.addEventListener("mouseup", onMouseDownIcidents);
-    $(".icidents-person-search-container").fadeIn(250);
+    document.addEventListener("mouseup", onMouseDownIncidents);
+    $(".incidents-person-search-container").fadeIn(250);
     $(".close-all").css("filter", "brightness(15%)");
   });
   $(".gallery-add-btn").click(function () {
@@ -1099,10 +1099,10 @@ $(document).ready(() => {
       }
 
       if (
-        $(".icidents-person-search-container").css("display") != "none"
+        $(".incidents-person-search-container").css("display") != "none"
       ) {
         shouldClose = false;
-        $(".icidents-person-search-container").fadeOut(250);
+        $(".incidents-person-search-container").fadeOut(250);
         $(".close-all").css("filter", "none");
       }
 
@@ -1150,9 +1150,9 @@ $(document).ready(() => {
     }
   });
 
-  $(".icidents-person-search-name-input").on("keydown", "", function (e) {
+  $(".incidents-person-search-name-input").on("keydown", "", function (e) {
     if (e.keyCode === 13) {
-      let name = $(".icidents-person-search-name-input").val();
+      let name = $(".incidents-person-search-name-input").val();
       $.post(
         `https://${GetParentResourceName()}/incidentSearchPerson`,
         JSON.stringify({
@@ -1982,11 +1982,11 @@ $(document).ready(() => {
       openContextMenu(e, args);
     }
   );
-  $(".icidents-person-search-holder").on(
+  $(".incidents-person-search-holder").on(
     "click",
-    ".icidents-person-search-item",
+    ".incidents-person-search-item",
     function () {
-      $(".icidents-person-search-container").fadeOut(250);
+      $(".incidents-person-search-container").fadeOut(250);
       $(".close-all").css("filter", "none");
       $(".associated-incidents-tags-holder").prepend(
         `<div class="associated-incidents-tag" data-id="${$(this).data(
@@ -2156,7 +2156,7 @@ $(document).ready(() => {
       }
     }
   });
-  $(".icidents-person-search-container").hover(
+  $(".incidents-person-search-container").hover(
     function () {
       mouse_is_inside = true;
     },
@@ -4081,7 +4081,7 @@ $(document).ready(() => {
         $(".callsign-container").fadeOut(0);
         $(".radio-inner-container").fadeOut(0);
         $(".radio-container").fadeOut(0);
-        $(".icidents-person-search-container").fadeOut(0);
+        $(".incidents-person-search-container").fadeOut(0);
         $(".dispatch-attached-units").fadeOut(0);
         $(".respond-calls").fadeOut(0);
         $(".respond-calls-container").fadeOut(0);
@@ -4744,18 +4744,18 @@ $(document).ready(() => {
       });
     } else if (eventData.type == "incidentSearchPerson") {
       let table = eventData.data;
-      $(".icidents-person-search-holder").empty();
+      $(".incidents-person-search-holder").empty();
       $.each(table, function (index, value) {
         let name = value.firstname + " " + value.lastname;
-        $(".icidents-person-search-holder").prepend(
+        $(".incidents-person-search-holder").prepend(
           `
-                    <div class="icidents-person-search-item" data-info="${name} (#${value.id})" data-cid="${value.id}" data-name="${name}">
-                        <img src="${value.profilepic}" class="icidents-person-search-item-pfp">
-                        <div class="icidents-person-search-item-right">
-                            <div class="icidents-person-search-item-right-cid-title">Citizen ID</div>
-                            <div class="icidents-person-search-item-right-cid-input"><span class="fas fa-id-card"></span> ${value.id}</div>
-                            <div class="icidents-person-search-item-right-name-title">Name</div>
-                            <div class="icidents-person-search-item-right-name-input"><span class="fas fa-user"></span> ${name}</div>
+                    <div class="incidents-person-search-item" data-info="${name} (#${value.id})" data-cid="${value.id}" data-name="${name}">
+                        <img src="${value.profilepic}" class="incidents-person-search-item-pfp">
+                        <div class="incidents-person-search-item-right">
+                            <div class="incidents-person-search-item-right-cid-title">Citizen ID</div>
+                            <div class="incidents-person-search-item-right-cid-input"><span class="fas fa-id-card"></span> ${value.id}</div>
+                            <div class="incidents-person-search-item-right-name-title">Name</div>
+                            <div class="incidents-person-search-item-right-name-input"><span class="fas fa-user"></span> ${name}</div>
                         </div>
                     </div>
                     `
@@ -5274,19 +5274,19 @@ function removeImage(url) {
     .remove();
 }
 
-function hideIcidentsMenu() {
+function hideIncidentsMenu() {
   if (
-    $(".icidents-person-search-container").css("display") != "none" &&
+    $(".incidents-person-search-container").css("display") != "none" &&
     !mouse_is_inside
   ) {
-    $(".icidents-person-search-container").fadeOut(250);
+    $(".incidents-person-search-container").fadeOut(250);
     $(".close-all").css("filter", "none");
   }
 }
 
-function onMouseDownIcidents(e) {
-  hideIcidentsMenu();
-  document.removeEventListener("mouseup", onMouseDownIcidents);
+function onMouseDownIncidents(e) {
+  hideIncidentsMenu();
+  document.removeEventListener("mouseup", onMouseDownIncidents);
 }
 
 function titleCase(str) {

--- a/ui/dashboard.html
+++ b/ui/dashboard.html
@@ -60,12 +60,12 @@
         </div>
     </div>
 
-    <div class="icidents-person-search">
-        <div class="icidents-person-search-container">
-            <div class="icidents-person-search-title">Person Search</div>
-            <div class="icidents-person-search-name-title">Name</div>
-            <div style="width: 95%; margin: auto; border-bottom: 2px solid #2C537B;"><input class="icidents-person-search-name-input"></div>
-            <div class="icidents-person-search-holder">
+    <div class="incidents-person-search">
+        <div class="incidents-person-search-container">
+            <div class="incidents-person-search-title">Person Search</div>
+            <div class="incidents-person-search-name-title">Name</div>
+            <div style="width: 95%; margin: auto; border-bottom: 2px solid #2C537B;"><input class="incidents-person-search-name-input"></div>
+            <div class="incidents-person-search-holder">
             </div>
         </div>
     </div>

--- a/ui/style.css
+++ b/ui/style.css
@@ -2789,6 +2789,29 @@ span.civilians-incident-input[contenteditable]:empty::before {
     background-color: rgba(0, 0, 0, 0);
 }
 
+.associated-incidents-controls {
+    display: flex;
+    justify-content: space-evenly;
+    width: 90%;
+    margin-top: 5px;
+    margin-bottom: 15px;
+}
+
+.control-button {
+    text-align: center;
+    background-color: var(--color-4);
+    padding: 10px;
+}
+
+.control-button span {
+    padding-right: 8px;
+}
+
+.control-button:hover {
+    background-color: var(--color-3);
+    cursor: pointer;
+}
+
 .icidents-person-search {
     display: flex;
     flex-direction: column;

--- a/ui/style.css
+++ b/ui/style.css
@@ -2812,7 +2812,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     cursor: pointer;
 }
 
-.icidents-person-search {
+.incidents-person-search {
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -2820,7 +2820,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     margin-top: 32.5vh;
 }
 
-.icidents-person-search-container {
+.incidents-person-search-container {
     background-color: var(--color-5);
     width: 95vh;
     height: 45vh;
@@ -2831,7 +2831,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     display: none;
 }
 
-.icidents-person-search-title {
+.incidents-person-search-title {
     background-color: var(--color-4);
     color: white;
     font-size: 20px;
@@ -2846,7 +2846,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     user-select: none;
 }
 
-.icidents-person-search-name-title {
+.incidents-person-search-name-title {
     width: 95%;
     margin: auto;
     margin-top: 10px;
@@ -2857,7 +2857,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     user-select: none;
 }
 
-.icidents-person-search-name-input {
+.incidents-person-search-name-input {
     background-color: rgba(0, 0, 0, 0);
     border: none;
     outline: none;
@@ -2870,7 +2870,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     padding-bottom: 2.5px;
 }
 
-.icidents-person-search-holder {
+.incidents-person-search-holder {
     overflow: auto;
     height: 30vh;
     width: 95%;
@@ -2879,18 +2879,18 @@ span.civilians-incident-input[contenteditable]:empty::before {
     margin-bottom: 15px;
 }
 
-.icidents-person-search-item {
+.incidents-person-search-item {
     width: 100%;
     height: 12.5vh;
     display: flex;
     flex-direction: row;
 }
 
-.icidents-person-search-item:hover {
+.incidents-person-search-item:hover {
     background-color: var(--color-3);
 }
 
-.icidents-person-search-item-pfp {
+.incidents-person-search-item-pfp {
     width: 11vh;
     height: 11vh;
     margin-top: auto;
@@ -2898,7 +2898,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     margin-left: 10px;
 }
 
-.icidents-person-search-item-right {
+.incidents-person-search-item-right {
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -2909,7 +2909,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     height: 11vh;
 }
 
-.icidents-person-search-item-right-cid-title {
+.incidents-person-search-item-right-cid-title {
     width: 100%;
     margin: auto;
     margin-top: 0px;
@@ -2920,7 +2920,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     user-select: none;
 }
 
-.icidents-person-search-item-right-cid-input {
+.incidents-person-search-item-right-cid-input {
     width: 100%;
     margin: auto;
     margin-top: 5px;
@@ -2933,7 +2933,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     user-select: none;
 }
 
-.icidents-person-search-item-right-name-title {
+.incidents-person-search-item-right-name-title {
     width: 100%;
     margin: auto;
     margin-top: auto;
@@ -2944,7 +2944,7 @@ span.civilians-incident-input[contenteditable]:empty::before {
     user-select: none;
 }
 
-.icidents-person-search-item-right-name-input {
+.incidents-person-search-item-right-name-input {
     width: 100%;
     margin: auto;
     margin-top: 5px;


### PR DESCRIPTION
# Overview
This PR adds 3 new buttons to the criminals involved box on the incidents page: jail, fine, community service. These buttons can be clicked and will immediately perform the action to the selected person. This adds more immersive functionality to the MDT and makes it so the user does not have to use the slash commands to jail and fine the person.

# Details
The buttons will show under each criminal listed on the incidents page.
- Jail - is currently tied into the qb-policejob JailPlayer event
- Fine - is using the `/bill` command that is in the current version of qb-phone
- CommunityService - is using a custom community service script

Each of these functions is set up so that any consumers can easily switch out the underlying jail, fine, communityservice functions with calls to whatever dependencies their server uses.

I also realize not everyone has a community service script and/or may not want this button, so I added a toggle `canSendToCommunityService` that will hide the button all together from the UI.

Additional changes:
- Fixed a typo `icident` to `incident`
- Refactored some code around the areas that I touched to make it easier to read/maintain and cleaned up duplicated code 

# UI
With community service enabled:
![image](https://user-images.githubusercontent.com/18689469/222664028-1b80458b-363b-4b05-9b6f-8a37a8e9b036.png)

With community service disabled:
![image](https://user-images.githubusercontent.com/18689469/222664038-da5c06b2-ca71-4ce0-9e75-7dcb63d7eda1.png)
