### PR TITLE
Add warrant indicator to profile page + profile search results

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -137,7 +137,7 @@ QBCore.Functions.CreateCallback('mdt:server:SearchProfile', function(source, cb,
 
 			if next(convictions) then
 				for _, conv in pairs(convictions) do
-					if conv.warrant then people[citizenIdIndexMap[conv.cid]].warrant = true end
+					if conv.warrant == "1" then people[citizenIdIndexMap[conv.cid]].warrant = true end
 
 					local charges = json.decode(conv.charges)
 					people[citizenIdIndexMap[conv.cid]].convictions = people[citizenIdIndexMap[conv.cid]].convictions + #charges
@@ -263,8 +263,8 @@ QBCore.Functions.CreateCallback('mdt:server:GetProfileData', function(source, cb
 		local convCount = 1
 		if next(convictions) then
 			for _, conv in pairs(convictions) do
-				if conv.warrant then person.warrant = true end
-
+				if conv.warrant == "1" then person.warrant = true end
+				
 				-- Get the incident details
 				local id = conv.linkedincident
 				local incident = GetIncidentName(id)

--- a/ui/app.js
+++ b/ui/app.js
@@ -5302,7 +5302,6 @@ function titleCase(str) {
 
 function searchProfilesResults(result) {
   canSearchForProfiles = true;
-  console.log('searchProfilesResults', result)
   $(".profile-items").empty();
 
   if (result.length < 1) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -195,6 +195,10 @@ $(document).ready(() => {
     $(".manage-profile-fingerprint").val(result["fingerprint"]);
     $(".manage-profile-fingerprint").removeAttr("disabled");
     $(".manage-profile-pic").attr("src", result["profilepic"] ?? "img/male.png");
+    $(".manage-profile-active-warrant").css("display", "none")
+    if (result["warrant"]) {
+      $(".manage-profile-active-warrant").css("display", "block");
+    }
 
     const { vehicles, tags, gallery, convictions, incidents, properties } = result
 
@@ -5298,6 +5302,7 @@ function titleCase(str) {
 
 function searchProfilesResults(result) {
   canSearchForProfiles = true;
+  console.log('searchProfilesResults', result)
   $(".profile-items").empty();
 
   if (result.length < 1) {
@@ -5377,6 +5382,10 @@ function searchProfilesResults(result) {
                           <div class="profile-item-title">${name}</div>
                               <div class="profile-tags">
                                   ${licences}
+                              </div>
+                              <div class="profile-criminal-tags">
+                                  <span class="license-tag ${warrant}">${value.warrant ? "Active" : "No"} Warrant</span>
+                                  <span class="license-tag ${convictions}">${value.convictions} Convictions </span>
                               </div>
                           </div>
                           <div class="profile-bottom-info">

--- a/ui/dashboard.html
+++ b/ui/dashboard.html
@@ -258,6 +258,7 @@
                     <div class="manage-profile-editing-title">You are currently editing ...</div>
                     <div class="manage-profile-save">Save</div>
                 </div>
+                <div class="manage-profile-active-warrant">ACTIVE WARRANT</div>
                 <div class="manage-profile-info-container">
                     <img src="img/male.png" class="manage-profile-pic" onerror="this.src='img/not-found.webp'">
                     <div class="manage-profile-info-inner-container">

--- a/ui/style.css
+++ b/ui/style.css
@@ -968,6 +968,14 @@ a {
     margin-bottom: 5px;
 }
 
+.profile-criminal-tags {
+    display: flex;
+    overflow-x: auto;
+    width: 100%;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
 .profile-tag {
     margin: auto;
     margin-left: 0px;
@@ -1191,6 +1199,15 @@ a {
     color: white;
     font-size: 16px;
     padding: 10px;
+}
+
+.manage-profile-active-warrant {
+    display: none;
+    margin: auto;
+    padding: 8px;
+    color: red;
+    font-weight: bold;
+    font-size: 20px;
 }
 
 .manage-profile-fingerprint {


### PR DESCRIPTION
# Details
Added a indicator on the profile page when the person has an active warrant.

Additionally updated the profile search results, to display the warrant status + the # of convictions. This was already partially setup, it just needed to be hooked into a UI element.

The `warrant` field in the database is currently a VARCHAR, however it is being used moreso as a boolean value (1 or 0). When we check for the truthyness of the field we need to compare against the string values "1" or "0". If we strictly only check truthyness of the warrant field, it will always be true because the string "0" is a truthy value. I opted to leave the DB structure alone so as to be a less disruptive change and to just account for this in the code instead.

# UI

Profile search results - showing Active Warrant or No Warrant + # Incidents
![image](https://user-images.githubusercontent.com/18689469/222927304-b08a1ad5-0e54-4149-a22e-7a4c6b46f971.png)

Added "Active Warrant" indicator on profile page
![image](https://user-images.githubusercontent.com/18689469/222927315-29b23b9e-1b50-449e-8a18-742fcfe9f3fd.png)

Field is not shown when there are no warrants
![image](https://user-images.githubusercontent.com/18689469/222927325-ea913b85-a043-45eb-b040-f609e44fa0e1.png)

