### PR TITLE
Player Unavailable Check

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1606,12 +1606,13 @@ end
 
 -- Returns the source for the given citizenId
 QBCore.Functions.CreateCallback('mdt:server:GetPlayerSourceId', function(source, cb, targetCitizenId)
-	local targetPlayer = QBCore.Functions.GetPlayerByCitizenId(targetCitizenId)
-	if targetPlayer == nil then return TriggerClientEvent('QBCore:Notify', source, "Citizen seems Asleep / Missing", "error") end
-	local targetSource = targetPlayer.PlayerData.source
+    local targetPlayer = QBCore.Functions.GetPlayerByCitizenId(targetCitizenId)
+    if targetPlayer == nil then 
+        return TriggerClientEvent('QBCore:Notify', source, "Citizen cannot be sent to jail, make sure they're in the city.", "error") 
+    end
+    local targetSource = targetPlayer.PlayerData.source
 
-	cb(targetSource)
-
+    cb(targetSource)
 end)
 
 QBCore.Functions.CreateCallback('getWeaponInfo', function(source, cb)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1607,6 +1607,7 @@ end
 -- Returns the source for the given citizenId
 QBCore.Functions.CreateCallback('mdt:server:GetPlayerSourceId', function(source, cb, targetCitizenId)
 	local targetPlayer = QBCore.Functions.GetPlayerByCitizenId(targetCitizenId)
+	if targetPlayer == nil then return TriggerClientEvent('QBCore:Notify', source, "Citizen seems Asleep / Missing", "error") end
 	local targetSource = targetPlayer.PlayerData.source
 
 	cb(targetSource)


### PR DESCRIPTION
This check is to inform a cop that the player they are trying to jail/fine/comserv is currently unavailable.... hence, they receive a notification informing such. That the "Citizen seems Asleep / Missing" other than popping errors in the console which confuses people more.... since no action happens on the client side