### PR TITLE
Update to fix the convictions not loading profiles when incidents are deleted.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -631,6 +631,7 @@ RegisterNetEvent('mdt:server:deleteIncidents', function(id)
 			if Config.LogPerms[Player.PlayerData.job.name][Player.PlayerData.job.grade.level] then
 				local fullName = Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname
 				MySQL.update("DELETE FROM `mdt_incidents` WHERE id=:id", { id = id }, function(rowsChanged)
+					MySQL.update('DELETE FROM mdt_convictions WHERE linkedincident=:linkedincident', {linkedincident = id})
 					if rowsChanged > 0 then
 						TriggerEvent('mdt:server:AddLog', "A Incident was deleted by "..fullName.." with the ID ("..id..")")
 					end


### PR DESCRIPTION
So now when you delete the incident, it deletes the convictions with since the profile fetch the incident and can't find it after the incident is deleted.