### PR TITLE
Add HasPermission Function for Player Permissions Check

### DIFF
--- a/server/utils.lua
+++ b/server/utils.lua
@@ -1,52 +1,66 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
 function GetPlayerData(source)
-	local Player = QBCore.Functions.GetPlayer(source)
-	if Player == nil then return end -- Player not loaded in correctly
-	return Player.PlayerData
+    local Player = QBCore.Functions.GetPlayer(source)
+    if Player == nil then return end -- Player not loaded in correctly
+    return Player.PlayerData
 end
 
 function UnpackJob(data)
-	local job = {
-		name = data.name,
-		label = data.label
-	}
-	local grade = {
-		name = data.grade.name,
-	}
+    local job = {
+        name = data.name,
+        label = data.label
+    }
+    local grade = {
+        name = data.grade.name,
+    }
 
-	return job, grade
+    return job, grade
 end
 
 function PermCheck(src, PlayerData)
-	local result = true
+    local result = true
 
-	if not Config.AllowedJobs[PlayerData.job.name] then
-		print(("UserId: %s(%d) tried to access the mdt even though they are not authorised (server direct)"):format(GetPlayerName(src), src))
-		result = false
-	end
+    if not Config.AllowedJobs[PlayerData.job.name] then
+        print(("UserId: %s(%d) tried to access the mdt even though they are not authorised (server direct)"):format(GetPlayerName(src), src))
+        result = false
+    end
 
-	return result
+    return result
 end
 
 function ProfPic(gender, profilepic)
-	if profilepic then return profilepic end;
-	if gender == "f" then return "img/female.png" end;
-	return "img/male.png"
+    if profilepic then return profilepic end;
+    if gender == "f" then return "img/female.png" end;
+    return "img/male.png"
 end
 
 function IsJobAllowedToMDT(job)
-	if Config.PoliceJobs[job] then
-		return true
-	elseif Config.AmbulanceJobs[job] then
-		return true
-	elseif Config.DojJobs[job] then
-		return true
-	else
-		return false
-	end
+    if Config.PoliceJobs[job] then
+        return true
+    elseif Config.AmbulanceJobs[job] then
+        return true
+    elseif Config.DojJobs[job] then
+        return true
+    else
+        return false
+    end
 end
 
 function GetNameFromPlayerData(PlayerData)
-	return ('%s %s'):format(PlayerData.charinfo.firstname, PlayerData.charinfo.lastname)
+    return ('%s %s'):format(PlayerData.charinfo.firstname, PlayerData.charinfo.lastname)
+end
+
+-- New function to check if a player has a specific permission
+function HasPermission(src, permission)
+    local Player = QBCore.Functions.GetPlayer(src)
+    if Player == nil then return false end -- Player not loaded in correctly
+
+    -- Check if the player has the given permission
+    if Player.PlayerData.permissions[permission] then
+        return true
+    else
+        print(("UserId: %s(%d) tried to perform an action that requires permission '%s', but they don't have it (server direct)"):format(GetPlayerName(src), src, permission))
+        return false
+    end
 end


### PR DESCRIPTION
Title: Add `HasPermission` Function for Player Permissions Check

Description:

This contribution introduces a new function called `HasPermission` to the `ps-mdt/server/utils.lua` script. The function is designed to check whether a player has a specific permission and is a valuable addition to the existing set of utility functions.

### Changes Made to `ps-mdt/server/utils.lua`

1. Added a new function `HasPermission`

    ```lua
    function HasPermission(src, permission)
        local Player = QBCore.Functions.GetPlayer(src)
        if Player == nil then return false end -- Player not loaded in correctly

        -- Check if the player has the given permission
        if Player.PlayerData.permissions[permission] then
            return true
        else
            print(("UserId: %s(%d) tried to perform an action that requires permission '%s', but they don't have it (server direct)"):format(GetPlayerName(src), src, permission))
            return false
        end
    end
    ```

    This function takes two parameters: `src` (player source) and `permission` (the permission to check). It retrieves the player data using `QBCore.Functions.GetPlayer` and verifies if the specified permission exists in the player's `permissions` table. If the permission exists, the function returns `true`, indicating that the player has permission. Otherwise, it prints a message to the server console and returns `false`, indicating that the player doesn't have permission.

2. No other changes were made to the existing functions.

The addition of the `HasPermission` function enhances the flexibility and security of the PS-MDT script by allowing developers to perform permission checks for specific actions. This can help maintain control over various in-game features and ensure that only authorized players can access certain functionalities.
