### PR TITLE
Reflect changes of QB-Management

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1872,8 +1872,8 @@ local function giveCitationItem(src, citizenId, fine, incidentId)
 	end
 	Player.Functions.AddItem('mdtcitation', 1, false, info)
 	TriggerClientEvent('QBCore:Notify', src, PlayerName.." (" ..citizenId.. ") received a citation!")
-	if Config.QBManagementUse then 
-		exports['qb-management']:AddMoney(Officer.PlayerData.job.name, fine) 
+	if Config.QBBankingUse then 
+		exports['qb-banking']:AddMoney(Officer.PlayerData.job.name, fine) 
 	end
 	TriggerClientEvent('inventory:client:ItemBox', Player.PlayerData.source, QBCore.Shared.Items['mdtcitation'], "add")
 	TriggerEvent('mdt:server:AddLog', "A Fine was writen by "..OfficerFullName.." and was sent to "..PlayerName..", the Amount was $".. fine ..". (ID: "..incidentId.. ")")

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -14,7 +14,7 @@ Config.BillVariation = true
 
 -- If set to false (default) = The fine amount is just being removed from the player's bank account
 -- If set to true = The fine amount is beeing added to the society account after being removed from the player's bank account
-Config.QBManagementUse = false
+Config.QBBankingUse = false
 
 -- Set up your inventory to automatically retrieve images when a weapon is registered at a weapon shop or self-registered.
 -- If you're utilizing lj-inventory's latest version from GitHub, no further modifications are necessary. 


### PR DESCRIPTION
QB-Management removed all the money functions and added them to QB-Banking. This is to reflect that change in QBCore.

I've also renamed the config variable from management to banking since the old wouldn't fit it's description.