### PR TITLE
feat(server/main): use ox_inventory hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,44 +26,7 @@ exports['ps-mdt']:CreateWeaponInfo(serial, imageurl, notes, owner, weapClass, we
 
 ## Setup for [ox_inventory](https://github.com/overextended/ox_inventory)
 
-* Find `ox_inventory:buyItem` on modules > shops> server.lua
-* Add the following code block
-```lua
-\\Existing code below for reference, put it right under it. \\
-local message = locale('purchased_for', count, fromItem.label, (currency == 'money' and locale('$') or math.groupdigits(price)), (currency == 'money' and math.groupdigits(price) or ' '..Items(currency).label))
-\\Existing code above for reference, put it right under it. \\
-
-if string.find(fromData.name, "WEAPON_") then
-					local serial = metadata.serial
-					local imageurl = ("https://cfx-nui-ox_inventory/web/images/%s.png"):format(fromData.name)
-					local notes = "Purchased from shop"
-					local owner = playerInv.owner
-					local weapClass = "Class"
-					local weapModel = fromData.name
-					
-					AddWeaponToMDT(serial, imageurl, notes, owner, weapClass, weapModel)
-				end
-```
-* Add the follow function towards the end of the script.
-```lua
-\\Existing code below for reference, put it right under it. \\
-server.shops = Shops
-\\Existing code above for reference, put it right under it. \\
-
-function AddWeaponToMDT(serial, imageurl, notes, owner, weapClass, weapModel)
-    Citizen.CreateThread(function()
-        Wait(500)
-
-        local success, result = pcall(function()
-            return exports['ps-mdt']:CreateWeaponInfo(serial, imageurl, notes, owner, weapClass, weapModel)
-        end)
-
-        if not success then
-            print("Unable to add weapon to MDT")
-        end
-    end)
-end
-```
+Set `Config.InventoryForWeaponsImages` to `"ox_inventory"` and `Config.RegisterCreatedWeapons` to true/false as desired.
 
 ## Self Register Weapons
 * Your citizens can self-register weapons found on their inventory. Event to trigger is below if you're using qb-target. There's also a command available named `registerweapon` but you'll need to uncomment if you want to use it.

--- a/server/main.lua
+++ b/server/main.lua
@@ -2088,3 +2088,50 @@ function generateMessageFromResult(result)
     message = message .. "Details: " .. details
     return message
 end
+
+if Config.InventoryForWeaponsImages == "ox_inventory" then
+	exports.ox_inventory:registerHook('buyItem', function(payload)
+		if not string.find(payload.itemName, "WEAPON_") then return true end
+		CreateThread(function()
+			local owner = QBCore.Functions.GetPlayer(payload.source).PlayerData.citizenid
+			if not owner or not payload.metadata.serial then return end
+			local imageurl = ("https://cfx-nui-ox_inventory/web/images/%s.png"):format(payload.itemName)
+			local notes = "Purchased from shop"
+			local weapClass = "Class"
+
+			local success, result = pcall(function()
+				return CreateWeaponInfo(payload.metadata.serial, imageurl, notes, owner, weapClass, payload.itemName)
+			end)
+
+			if not success then
+				print("Error in creating weapon info in MDT: " .. result)
+			end
+		end)
+		return true
+	end, {
+		typeFilter = { ['player'] = true }
+	})
+	if Config.RegisterCreatedWeapons then -- This is for other shop resources that use the AddItem method. Will also capture items created at benches.
+		exports.ox_inventory:registerHook('createItem', function(payload)
+			if not string.find(payload.item.name, "WEAPON_") then return true end
+			CreateThread(function()
+				local owner = QBCore.Functions.GetPlayer(payload.inventoryId).PlayerData.citizenid
+				if not owner or not payload.metadata.serial then return end
+				local imageurl = ("https://cfx-nui-ox_inventory/web/images/%s.png"):format(payload.item.name)
+				local notes = "Purchased from shop"
+				local weapClass = "Class"
+
+				local success, result = pcall(function()
+					return CreateWeaponInfo(payload.metadata.serial, imageurl, notes, owner, weapClass, payload.item.name)
+				end)
+
+				if not success then
+					print("Error in creating weapon info in MDT: " .. result)
+				end
+			end)
+			return true
+		end, {
+			typeFilter = { ['player'] = true }
+		})
+	end
+end

--- a/server/main.lua
+++ b/server/main.lua
@@ -2089,7 +2089,7 @@ function generateMessageFromResult(result)
     return message
 end
 
-if Config.InventoryForWeaponsImages == "ox_inventory" then
+if Config.InventoryForWeaponsImages == "ox_inventory" and Config.RegisterWeaponsAutomatically then
 	exports.ox_inventory:registerHook('buyItem', function(payload)
 		if not string.find(payload.itemName, "WEAPON_") then return true end
 		CreateThread(function()

--- a/server/main.lua
+++ b/server/main.lua
@@ -2097,7 +2097,7 @@ if Config.InventoryForWeaponsImages == "ox_inventory" then
 			if not owner or not payload.metadata.serial then return end
 			local imageurl = ("https://cfx-nui-ox_inventory/web/images/%s.png"):format(payload.itemName)
 			local notes = "Purchased from shop"
-			local weapClass = "Class"
+			local weapClass = "Class" --@TODO retrieve class better
 
 			local success, result = pcall(function()
 				return CreateWeaponInfo(payload.metadata.serial, imageurl, notes, owner, weapClass, payload.itemName)
@@ -2111,7 +2111,12 @@ if Config.InventoryForWeaponsImages == "ox_inventory" then
 	end, {
 		typeFilter = { ['player'] = true }
 	})
-	if Config.RegisterCreatedWeapons then -- This is for other shop resources that use the AddItem method. Will also capture items created at benches.
+	-- This is for other shop resources that use the AddItem method. 
+	-- Only registers weapons with serial numbers, must specify a slot in ox_inventory:AddItem with metadata
+	-- metadata = {
+	--   registered = true
+	-- }
+	if Config.RegisterCreatedWeapons then
 		exports.ox_inventory:registerHook('createItem', function(payload)
 			if not string.find(payload.item.name, "WEAPON_") then return true end
 			CreateThread(function()
@@ -2119,7 +2124,7 @@ if Config.InventoryForWeaponsImages == "ox_inventory" then
 				if not owner or not payload.metadata.serial then return end
 				local imageurl = ("https://cfx-nui-ox_inventory/web/images/%s.png"):format(payload.item.name)
 				local notes = "Purchased from shop"
-				local weapClass = "Class"
+				local weapClass = "Class" --@TODO retrieve class better
 
 				local success, result = pcall(function()
 					return CreateWeaponInfo(payload.metadata.serial, imageurl, notes, owner, weapClass, payload.item.name)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -29,6 +29,9 @@ Config.QBBankingUse = false
 -- However, if you're using a different inventory system, please refer to the "Inventory Edit | Automatic Add Weapons with images" section in ps-mdt's README.
 Config.InventoryForWeaponsImages = "lj-inventory"
 
+-- Only compatible with ox_inventory
+Config.RegisterWeaponsAutomatically = true
+
 -- Set to true to register all weapons that are added via AddItem in ox_inventory
 Config.RegisterCreatedWeapons = true
 

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -29,6 +29,9 @@ Config.QBBankingUse = false
 -- However, if you're using a different inventory system, please refer to the "Inventory Edit | Automatic Add Weapons with images" section in ps-mdt's README.
 Config.InventoryForWeaponsImages = "lj-inventory"
 
+-- Set to true to register all weapons that are added via AddItem in ox_inventory
+Config.RegisterCreatedWeapons = true
+
 -- "LegacyFuel", "lj-fuel", "ps-fuel"
 Config.Fuel = "ps-fuel"
 


### PR DESCRIPTION
ox_inventory supports hooks for extending functionality. This enables this capability while removing the need to modify ox_inventory code to support automatic registration.