### PR TITLE
Resolve transient error fix on mugshot upload

### DIFF
--- a/client/cl_mugshot.lua
+++ b/client/cl_mugshot.lua
@@ -41,10 +41,13 @@ end
 local function PhotoProcess(ped)
     local rotation = suspectheading
     for photo = 1, Config.MugPhotos, 1 do
-        Wait(1500)
         TakeMugShot()
+        -- Transient error can occur if we don't wait long enough for the array to be pushed with the new mugshot
+        -- URL. So we wait until this has happened.
+        while #MugshotArray == 0 do
+            Wait(1000)
+        end
         PlaySoundFromCoord(-1, "SHUTTER_FLASH", x, y, z, "CAMERA_FLASH_SOUNDSET", true, 5, 0)
-        Wait(1500)
         rotation = rotation - 90.0
         SetEntityHeading(ped, rotation)
     end
@@ -197,7 +200,7 @@ RegisterNetEvent('cqc-mugshot:client:trigger', function()
             SetEntityHeading(ped, suspectheading)
             ClearPedSecondaryTask(GetPlayerPed(ped))
         end
-           TriggerServerEvent('psmdt-mugshot:server:MDTupload', playerData.citizenid, MugshotArray)
+        TriggerServerEvent('psmdt-mugshot:server:MDTupload', playerData.citizenid, MugshotArray)
         mugshotInProgress = false
     end)
 end)

--- a/client/cl_mugshot.lua
+++ b/client/cl_mugshot.lua
@@ -41,6 +41,7 @@ end
 local function PhotoProcess(ped)
     local rotation = suspectheading
     for photo = 1, Config.MugPhotos, 1 do
+        Wait(1500)
         TakeMugShot()
         -- Transient error can occur if we don't wait long enough for the array to be pushed with the new mugshot
         -- URL. So we wait until this has happened.

--- a/server/main.lua
+++ b/server/main.lua
@@ -588,11 +588,11 @@ end)
 RegisterNetEvent('psmdt-mugshot:server:MDTupload', function(citizenid, MugShotURLs)
     MugShots[citizenid] = MugShotURLs
     local cid = citizenid
-    MySQL.Async.insert('INSERT INTO mdt_data (cid, pfp, gallery, tags) VALUES (:cid, :pfp, :gallery, :tags) ON DUPLICATE KEY UPDATE cid = :cid,  pfp = :pfp, tags = :tags, gallery = :gallery', {
+    MySQL.Async.insert('INSERT INTO mdt_data (cid, pfp, gallery, tags) VALUES (:cid, :pfp, :gallery, :tags) ON DUPLICATE KEY UPDATE cid = :cid,  pfp = :pfp, gallery = :gallery, tags = :tags', {
 		cid = cid,
-		pfp = MugShotURLs[1],
+		pfp = MugShots[citizenid][1],
+		gallery = json.encode(MugShots[citizenid]),
 		tags = json.encode(tags),
-		gallery = json.encode(MugShotURLs),
 	})
 end)
 


### PR DESCRIPTION
## The Transient Error problem
It was reported in the Discord that Fivemerr was not uploading the Mugshot correctly to the MDT profile page. Following my last implementation in this PR https://github.com/Project-Sloth/ps-mdt/pull/487 which allows this. It still was a bit "touch and go" on if the image was actually attached to the MDT profile.

After investigation, it seems that the original `Wait()`'s in here were good enough for the response time from Discord's API for the attachment URL but they are only _sometimes_ good enough for Fivemerr depending on load at the time of upload. Hence why it works sometimes for me (Like in the previous PR) and sometimes it does not.

After investigation, it seems the `TriggerServerEvent` that uploads it to the MDT was happening just a bit too _soon_ before the `MugshotUrls` was populated with the Fivemerr link, simply because Fivemerr had not responded yet. 

## Resolution

Because we wipe `MugshotUrls` before the entire mugshot process commences every time, instead of calling `Wait()` twice, one before the mugshot and one after with an arbitrary number. I've added a while loop which waits until the MugshotUrl variable has been set. This way we're "sort of" making Screenshot Basic's response asyncronous. However, it would be nicer to tailor this in a cleaner way when we release the Fivemerr SDK.

I also sorted some of the orders with the SQL query, it wasn't in the correct order if we were calling update. It doesn't matter on order thanks to naming our variables but readability is also a nice thing.