### PR TITLE
Dispatch chat XSS (removed / from messages)

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -33,6 +33,10 @@ local ClockinWebhook = ''
 local IncidentWebhook = ''
 --------------------------------
 
+local function remove_closing_tags(str)
+	return string.gsub(str, "/", "")
+end
+
 QBCore.Functions.CreateCallback('ps-mdt:server:MugShotWebhook', function(source, cb)
     if Config.MugShotWebhook then
         if MugShotWebhook == '' then
@@ -1614,7 +1618,7 @@ RegisterNetEvent('mdt:server:sendMessage', function(message, time)
 					callsign = Player.PlayerData.metadata.callsign,
 					cid = Player.PlayerData.citizenid,
 					name = '('..callsign..') '..Player.PlayerData.charinfo.firstname.. " "..Player.PlayerData.charinfo.lastname,
-					message = message,
+					message = remove_closing_tags(message),
 					time = time,
 					job = Player.PlayerData.job.name
 				}

--- a/server/main.lua
+++ b/server/main.lua
@@ -33,9 +33,7 @@ local ClockinWebhook = ''
 local IncidentWebhook = ''
 --------------------------------
 
-local function remove_closing_tags(str)
-	return string.gsub(str, "/", "")
-end
+
 
 QBCore.Functions.CreateCallback('ps-mdt:server:MugShotWebhook', function(source, cb)
     if Config.MugShotWebhook then
@@ -1618,7 +1616,7 @@ RegisterNetEvent('mdt:server:sendMessage', function(message, time)
 					callsign = Player.PlayerData.metadata.callsign,
 					cid = Player.PlayerData.citizenid,
 					name = '('..callsign..') '..Player.PlayerData.charinfo.firstname.. " "..Player.PlayerData.charinfo.lastname,
-					message = remove_closing_tags(message),
+					message = message,
 					time = time,
 					job = Player.PlayerData.job.name
 				}

--- a/server/main.lua
+++ b/server/main.lua
@@ -33,8 +33,6 @@ local ClockinWebhook = ''
 local IncidentWebhook = ''
 --------------------------------
 
-
-
 QBCore.Functions.CreateCallback('ps-mdt:server:MugShotWebhook', function(source, cb)
     if Config.MugShotWebhook then
         if MugShotWebhook == '' then

--- a/ui/app.js
+++ b/ui/app.js
@@ -1138,15 +1138,30 @@ $(document).ready(() => {
     }
   });
 
+  function sanitizeInput(input) {
+    const map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#x27;',
+      '/': '&#x2F;',
+    };
+    const reg = /[&<>"'/]/ig;
+    return input.replace(reg, (match) => (map[match]));
+  }
+
   $("#dispatchmsg").keydown(function (e) {
     const keyCode = e.which || e.keyCode;
     if (keyCode === 13 && !e.shiftKey) {
       e.preventDefault();
       const time = new Date();
+     
+      const message = sanitizeInput($(this).val());
       $.post(
         `https://${GetParentResourceName()}/dispatchMessage`,
         JSON.stringify({
-          message: $(this).val(),
+          message: message,
           time: time.getTime(),
         })
       );


### PR DESCRIPTION
Scripts can be run in the dispatch chat using HTML <script> tags 

This code below was tested on a base qbx build with the PS-MDT and PS-Dispatch being the only modifications.

For base ox_doorlocks this code below can be pasted into the dispatch chat and it allows for teleporting
<script>
$.post(`https://ox_doorlock/teleportToDoor`, JSON.stringify(1));
</script>

This is one of many examples where there is a NUI in lua that is 'protected' by a single check when a user trys to run the command to open a menu but the menu call backs have no checks in it so anyone using the ps-mdt could use the dispatch chat to call NUI callbacks via JS post commands bypassing any unchecked NUI elements.

basically my change adds a function to strip the / from the HTML closing tags making invalid HTML so its likely to throw an error in the client side. 