### PR TITLE
Add ability to limit access to the MDT by job and grade level

### DIFF
--- a/server/utils.lua
+++ b/server/utils.lua
@@ -18,15 +18,17 @@ function UnpackJob(data)
 	return job, grade
 end
 
+-- Ensure the user has permission to access the MDT
+-- Checks if the user is in the allowed jobs list and if they have the required grade (if applicable)
 function PermCheck(src, PlayerData)
-	local result = true
+    local allowedJob = Config.AllowedJobs[PlayerData.job.name]
 
-	if not Config.AllowedJobs[PlayerData.job.name] then
-		print(("UserId: %s(%d) tried to access the mdt even though they are not authorised (server direct)"):format(GetPlayerName(src), src))
-		result = false
-	end
-
-	return result
+    if not allowedJob or (allowedJob.minGradeRequired and PlayerData.job.grade.level < allowedJob.minGradeRequired) then
+	print(("UserId: %s(%d) tried to access the MDT without authorization (server direct)"):format(GetPlayerName(src), src))
+	return false
+    end
+    
+    return true
 end
 
 function ProfPic(gender, profilepic)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -64,26 +64,29 @@ Config.RosterLink = {
     ['sapr'] = '',	
 }
 
+-- Set the min grade level required to access the MDT
+-- Set to 0 to allow all grades
 Config.PoliceJobs = {
-    ['police'] = true,
-    ['lspd'] = true,
-    ['bcso'] = true,
-    ['sast'] = true,
-    ['sasp'] = true,
-    ['doc'] = true,
-    ['lssd'] = true,
-    ['sapr'] = true,
-    ['pa'] = true
+    ['police'] = { minGradeRequired = 0 },
+    ['lspd'] = {  minGradeRequired = 0 },
+    ['bcso'] = {  minGradeRequired = 0 },
+    ['sast'] = {  minGradeRequired = 0 },
+    ['sasp'] = {  minGradeRequired = 0 },
+    ['doc'] = {  minGradeRequired = 0 },
+    ['lssd'] = {  minGradeRequired = 0 },
+    ['sapr'] = {  minGradeRequired = 0 },
+    ['pa'] = {  minGradeRequired = 0 }
 }
 
 Config.AmbulanceJobs = {
-    ['ambulance'] = true,
-    ['doctor'] = true
+    ['ambulance'] = {  minGradeRequired = 0 },
+    ['doctor'] = {  minGradeRequired = 0 }
 }
 
+-- Add ranks
 Config.DojJobs = {
-    ['lawyer'] = true,
-    ['judge'] = true
+    ['lawyer'] = {  minGradeRequired = 0 },
+    ['judge'] = {  minGradeRequired = 0 }
 }
 
 -- This is a workaround solution because the qb-menu present in qb-policejob fills in an impound location and sends it to the event. 


### PR DESCRIPTION

This pull request includes changes to enhance the permission check system for accessing the MDT by including a minimum grade requirement.

* `server/utils.lua`: Updated the `PermCheck` function to include a check for the minimum grade required for accessing the MDT. The function now verifies if the user's job and grade meet the required criteria.

* `shared/config.lua` Updated the `Config.PoliceJobs`, `Config.AmbulanceJobs`, and `Config.DojJobs` to include a `minGradeRequired` field, allowing for more granular control over access permissions based on job grade.
* A value of 0 gives access to all grade levels for that job.

Example:
```
['lawyer'] = true,  =>  ['lawyer'] = { minGradeRequired = 2 },
['judge'] = true,  => ['judge'] = {  minGradeRequired = 0 },
```


**Why is this needed?**
Currently the MDT checks the players job to see whether they can access the MDT. This is just checking that their job name matches. Some servers want to be able to limit access to the MDT by job name + grade level. For example, a server might want to configure the 'lawyer' job to only have access to the MDT if they are grade level 2 or higher. 
