### PR TITLE
feat(services): refactor auth and color configuration flow

### DIFF
--- a/web/src/components/management/ManagementColors.svelte
+++ b/web/src/components/management/ManagementColors.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { onMount } from "svelte";
-	import { fetchNui } from "../../utils/fetchNui";
-	import { isEnvBrowser } from "../../utils/misc";
-	import { NUI_EVENTS } from "../../constants/nuiEvents";
+	import { fetchNui } from "@/utils/fetchNui";
+	import { isEnvBrowser } from "@/utils/misc";
+	import { NUI_EVENTS } from "@/constants/nuiEvents";
+	import { settingsService } from "@/services/settingsService.svelte";
 
 	interface ColorConfig {
 		accent: string;
@@ -11,7 +12,6 @@
 		cardBackground: string;
 		buttonPrimary: string;
 	}
-
 	const DEFAULT_LEO: ColorConfig = {
 		accent: "59, 130, 246",
 		accentText: "147, 197, 253",
@@ -61,11 +61,11 @@
 	let selectedTheme: string | null = $state(null);
 
 	let hasChanges = $derived(
-		config.accent !== savedConfig.accent ||
-		config.accentText !== savedConfig.accentText ||
-		config.background !== savedConfig.background ||
-		config.cardBackground !== savedConfig.cardBackground ||
-		config.buttonPrimary !== savedConfig.buttonPrimary
+			config.accent !== savedConfig.accent ||
+			config.accentText !== savedConfig.accentText ||
+			config.background !== savedConfig.background ||
+			config.cardBackground !== savedConfig.cardBackground ||
+			config.buttonPrimary !== savedConfig.buttonPrimary
 	);
 
 	function showStatus(text: string, type: "success" | "error" = "success") {
@@ -123,23 +123,24 @@
 
 	async function loadConfig() {
 		if (isEnvBrowser()) return;
-		try {
-			isLoading = true;
-			const response = await fetchNui<ColorConfig | null>(
-				NUI_EVENTS.SETTINGS.GET_COLOR_CONFIG,
-				{},
-				null,
-			);
-			if (response && typeof response === "object" && response.accent) {
-				config = { ...DEFAULT_LEO, ...response };
-				savedConfig = { ...config };
-				applyPreview();
-			}
-		} catch (error) {
-			console.error("Failed to load color config:", error);
-		} finally {
-			isLoading = false;
+
+		if (settingsService.isLoading) return;
+
+		if (!settingsService.colorConfig) {
+			await settingsService.loadColorConfig();
 		}
+
+		if (settingsService.error) {
+			showStatus(settingsService.error, "error");
+			return;
+		}
+
+		if (settingsService.colorConfig) {
+			config = { ...DEFAULT_LEO, ...settingsService.colorConfig };
+			savedConfig = { ...config };
+			applyPreview();
+		}
+
 	}
 
 	async function saveConfig() {
@@ -151,12 +152,13 @@
 		try {
 			isSaving = true;
 			const result = await fetchNui<{ success: boolean; message?: string }>(
-				NUI_EVENTS.SETTINGS.SAVE_COLOR_CONFIG,
-				config,
-				{ success: false },
+					NUI_EVENTS.SETTINGS.SAVE_COLOR_CONFIG,
+					config,
+					{ success: false },
 			);
 			if (result?.success) {
 				savedConfig = { ...config };
+				settingsService.setColorConfig(config);
 				showStatus("Colors saved - applies to all officers on next MDT open");
 			} else {
 				showStatus(result?.message || "Failed to save colors", "error");
@@ -186,9 +188,9 @@
 					{#each COLOR_FIELDS as field}
 						<div class="color-tile">
 							<input
-								type="color"
-								value={rgbToHex(config[field.key])}
-								oninput={(e) => updateField(field.key, (e.target as HTMLInputElement).value)}
+									type="color"
+									value={rgbToHex(config[field.key])}
+									oninput={(e) => updateField(field.key, (e.target as HTMLInputElement).value)}
 							/>
 							<span class="tile-name">{field.label}</span>
 							<span class="tile-desc">{field.description}</span>
@@ -203,9 +205,9 @@
 				<div class="themes-hz">
 					{#each THEMES as theme}
 						<button
-							class="theme-card"
-							class:active={selectedTheme === theme.name}
-							onclick={() => applyTheme(theme)}
+								class="theme-card"
+								class:active={selectedTheme === theme.name}
+								onclick={() => applyTheme(theme)}
 						>
 							<div class="theme-preview" style="background: rgb({theme.config.background})">
 								<div class="theme-sidebar" style="background: rgb({theme.config.cardBackground})">

--- a/web/src/pages/MDT.svelte
+++ b/web/src/pages/MDT.svelte
@@ -1,200 +1,178 @@
 <script lang="ts">
-	import { onMount } from "svelte";
-	import { useNuiEvent } from "../utils/useNuiEvent";
-	import { setupDevelopmentMode } from "../utils/developmentMode";
-	import { createAuthService } from "../services/authService.svelte";
-	import { createTabService } from "../services/tabService.svelte";
-	import { createInstanceStateService } from "../services/instanceStateService.svelte";
-	import { NUI_EVENTS } from "../constants/nuiEvents";
-	import { fetchNui } from "../utils/fetchNui";
-	import { isEnvBrowser } from "../utils/misc";
-	import type { MDTTab } from "../constants";
-	import TopBar from "../components/TopBar.svelte";
-	import NavigationPills from "../components/NavigationPills.svelte";
-	import InstanceTabs from "../components/InstanceTabs.svelte";
-	import ContentArea from "../components/ContentArea.svelte";
-	import type { AuthUpdateData } from "../interfaces/IUser";
-	const authService = createAuthService();
-	const tabService = createTabService();
-	const instanceStateService = createInstanceStateService(tabService);
+    import {onMount} from "svelte";
+    import {useNuiEvent} from "@/utils/useNuiEvent";
+    import {setupDevelopmentMode} from "@/utils/developmentMode";
+    import {createAuthService} from "../services/authService.svelte";
+    import {createTabService} from "../services/tabService.svelte";
+    import {settingsService} from "../services/settingsService.svelte";
+    import {createInstanceStateService} from "../services/instanceStateService.svelte";
+    import {NUI_EVENTS} from "@/constants/nuiEvents";
+    import TopBar from "../components/TopBar.svelte";
+    import NavigationPills from "../components/NavigationPills.svelte";
+    import InstanceTabs from "../components/InstanceTabs.svelte";
+    import ContentArea from "../components/ContentArea.svelte";
+    import type {AuthUpdateData} from "@/interfaces/IUser";
 
-	let opacityStyle = $state("opacity: 1");
+    const authService = createAuthService();
+    const tabService = createTabService();
+    const instanceStateService = createInstanceStateService(tabService);
 
-	function handleOpacityStyleChange(style: string): void {
-		opacityStyle = style;
-	}
+    let opacityStyle = $state("opacity: 1");
 
-onMount(() => {
-		authService.checkAuth();
-		loadSavedColors();
-		setupInstanceCoordination();
-	});
+    function handleOpacityStyleChange(style: string): void {
+        opacityStyle = style;
+    }
 
-	async function loadSavedColors() {
-		if (isEnvBrowser()) return;
-		try {
-			const config = await fetchNui<{ accent?: string; accentText?: string; background?: string; cardBackground?: string; buttonPrimary?: string } | null>(
-				NUI_EVENTS.SETTINGS.GET_COLOR_CONFIG,
-				{},
-				null,
-			);
-			if (config && typeof config === "object" && config.accent) {
-				const root = document.documentElement;
-				root.style.setProperty("--accent-rgb", config.accent);
-				if (config.accentText) root.style.setProperty("--accent-text-rgb", config.accentText);
-				if (config.background) root.style.setProperty("--dark-bg", `rgb(${config.background})`);
-				if (config.cardBackground) root.style.setProperty("--card-dark-bg", `rgb(${config.cardBackground})`);
-				if (config.buttonPrimary) root.style.setProperty("--btn-primary", `rgb(${config.buttonPrimary})`);
-			}
-		} catch {
-			// Silently fail - use defaults
-		}
-	}
+    onMount(() => {
+        authService.checkAuth();
+        settingsService.loadColorConfig();
+        setupInstanceCoordination();
+    });
 
-	function setupInstanceCoordination(): void {
-		$effect(() => {
-			const activeInstance = tabService.getActiveInstance();
-			if (activeInstance) {
-				instanceStateService.switchToInstance(
-					activeInstance.id,
-					activeInstance.currentTab,
-				);
-			}
-		});
-	}
+    function setupInstanceCoordination(): void {
+        $effect(() => {
+            const activeInstance = tabService.getActiveInstance();
+            if (activeInstance) {
+                instanceStateService.switchToInstance(
+                    activeInstance.id,
+                    activeInstance.currentTab,
+                );
+            }
+        });
+    }
 
-	useNuiEvent<AuthUpdateData>(
-		NUI_EVENTS.AUTH.UPDATE_AUTH,
-		(data: AuthUpdateData) => {
-			authService.updateAuthState(data);
-		},
-	);
+    useNuiEvent<AuthUpdateData>(
+        NUI_EVENTS.AUTH.UPDATE_AUTH,
+        (data: AuthUpdateData) => {
+            authService.updateAuthState(data);
+        },
+    );
 
-	setupDevelopmentMode();
+    setupDevelopmentMode();
 
-	if (typeof document !== 'undefined') {
-		let lastFocusedInput: HTMLElement | null = null;
-		let refocusPending = false;
+    if (typeof document !== 'undefined') {
+        let lastFocusedInput: HTMLElement | null = null;
+        let refocusPending = false;
 
-		document.addEventListener('focusin', (e) => {
-			const el = e.target as HTMLElement;
-			if (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA' || el.isContentEditable) {
-				lastFocusedInput = el;
-				refocusPending = false;
-			}
-		});
+        document.addEventListener('focusin', (e) => {
+            const el = e.target as HTMLElement;
+            if (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA' || el.isContentEditable) {
+                lastFocusedInput = el;
+                refocusPending = false;
+            }
+        });
 
-		document.addEventListener('focusout', (e) => {
-			const fe = e as FocusEvent;
-			const el = e.target as HTMLElement;
-			// Skip SELECT elements - their dropdown interaction triggers focusout with null relatedTarget
-			if (el.tagName === 'SELECT') return;
-			if (fe.relatedTarget === null && lastFocusedInput === el && !refocusPending) {
-				refocusPending = true;
-				requestAnimationFrame(() => {
-					if (lastFocusedInput && (!document.activeElement || document.activeElement === document.body)) {
-						lastFocusedInput.focus();
-					}
-					refocusPending = false;
-				});
-			}
-		});
+        document.addEventListener('focusout', (e) => {
+            const fe = e as FocusEvent;
+            const el = e.target as HTMLElement;
+            // Skip SELECT elements - their dropdown interaction triggers focusout with null relatedTarget
+            if (el.tagName === 'SELECT') return;
+            if (fe.relatedTarget === null && lastFocusedInput === el && !refocusPending) {
+                refocusPending = true;
+                requestAnimationFrame(() => {
+                    if (lastFocusedInput && (!document.activeElement || document.activeElement === document.body)) {
+                        lastFocusedInput.focus();
+                    }
+                    refocusPending = false;
+                });
+            }
+        });
 
-	}
+    }
 </script>
 
 <main class="mdt-container" data-job-type={authService.jobType}>
-	<div class="mdt-window" style={opacityStyle}>
-		<div class="mdt-interface">
-			<TopBar
-				{authService}
-				onOpacityStyleChange={handleOpacityStyleChange}
-			/>
+    <div class="mdt-window" style={opacityStyle}>
+        <div class="mdt-interface">
+            <TopBar
+                    {authService}
+                    onOpacityStyleChange={handleOpacityStyleChange}
+            />
 
-			<div class="mdt-content">
-				{#if !authService.isCivilian}
-					<div class="mdt-navigation">
-						{#if authService.isAuthorized}
-							<NavigationPills {tabService} jobType={authService.jobType} {authService} />
-						{/if}
-					</div>
-				{/if}
-				<div class="mdt-main-content">
-					{#if !authService.isCivilian}
-						<InstanceTabs {tabService} />
-					{/if}
-					<ContentArea
-						{authService}
-						{tabService}
-						{instanceStateService}
-					/>
-				</div>
-			</div>
-		</div>
-	</div>
+            <div class="mdt-content">
+                {#if !authService.isCivilian}
+                    <div class="mdt-navigation">
+                        {#if authService.isAuthorized}
+                            <NavigationPills {tabService} jobType={authService.jobType} {authService}/>
+                        {/if}
+                    </div>
+                {/if}
+                <div class="mdt-main-content">
+                    {#if !authService.isCivilian}
+                        <InstanceTabs {tabService}/>
+                    {/if}
+                    <ContentArea
+                            {authService}
+                            {tabService}
+                            {instanceStateService}
+                    />
+                </div>
+            </div>
+        </div>
+    </div>
 </main>
 
 <style>
-	.mdt-container {
-		position: fixed;
-		top: 0;
-		left: 0;
-		width: 100vw;
-		height: 100vh;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		z-index: 1000;
-	}
+    .mdt-container {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+    }
 
-	.mdt-window {
-		width: 95vw;
-		height: 90vh;
-		background: var(--dark-bg);
-		border-radius: 12px;
-		overflow: hidden;
-		display: flex;
-		flex-direction: column;
-		box-shadow: 0 20px 40px rgba(23, 23, 23, 0.3);
-		border: 1px solid transparent;
-		position: relative;
-		transition: opacity 0.2s ease-in-out;
-		will-change: opacity;
-	}
+    .mdt-window {
+        width: 95vw;
+        height: 90vh;
+        background: var(--dark-bg);
+        border-radius: 12px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        box-shadow: 0 20px 40px rgba(23, 23, 23, 0.3);
+        border: 1px solid transparent;
+        position: relative;
+        transition: opacity 0.2s ease-in-out;
+        will-change: opacity;
+    }
 
-	:global([data-job-type="ems"]) .mdt-window {
-		border-color: rgba(220, 50, 50, 0.15);
-		box-shadow: 0 20px 40px rgba(20, 8, 8, 0.4), 0 0 60px rgba(220, 50, 50, 0.04);
-	}
+    :global([data-job-type="ems"]) .mdt-window {
+        border-color: rgba(220, 50, 50, 0.15);
+        box-shadow: 0 20px 40px rgba(20, 8, 8, 0.4), 0 0 60px rgba(220, 50, 50, 0.04);
+    }
 
-	:global([data-job-type="doj"]) .mdt-window {
-		border-color: rgba(180, 150, 60, 0.15);
-		box-shadow: 0 20px 40px rgba(8, 12, 20, 0.4), 0 0 60px rgba(30, 58, 138, 0.04);
-	}
+    :global([data-job-type="doj"]) .mdt-window {
+        border-color: rgba(180, 150, 60, 0.15);
+        box-shadow: 0 20px 40px rgba(8, 12, 20, 0.4), 0 0 60px rgba(30, 58, 138, 0.04);
+    }
 
-	.mdt-interface {
-		width: 100%;
-		height: 100%;
-		display: flex;
-		flex-direction: column;
-	}
+    .mdt-interface {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
 
-	.mdt-content {
-		display: flex;
-		height: calc(100% - 55px); /* Adjust for TopBar height */
-	}
+    .mdt-content {
+        display: flex;
+        height: calc(100% - 55px); /* Adjust for TopBar height */
+    }
 
-	.mdt-navigation {
-		max-width: 250px;
-		background: var(--card-dark-bg);
-		display: flex;
-	}
+    .mdt-navigation {
+        max-width: 250px;
+        background: var(--card-dark-bg);
+        display: flex;
+    }
 
-	.mdt-main-content {
-		display: flex;
-		flex-direction: column;
-		flex: 1;
-		min-width: 0;
-		width: 100%;
-	}
+    .mdt-main-content {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+        width: 100%;
+    }
 </style>

--- a/web/src/services/authService.svelte.ts
+++ b/web/src/services/authService.svelte.ts
@@ -1,21 +1,9 @@
-import type { PlayerData } from "./../interfaces/IPlayerData";
-import { fetchNui } from "../utils/fetchNui";
-import { debugError } from "../utils/debug";
-import { TIMING } from "../constants";
-import { NUI_EVENTS } from "../constants/nuiEvents";
-import type { AuthUpdateData } from "../interfaces/IUser";
-import type { JobType } from "../interfaces/IUser";
-
-export interface AuthState {
-	isAuthorized: boolean;
-	isCheckingAuth: boolean;
-	authError: string;
-	playerData: PlayerData | null;
-	isLEO: boolean;
-	onDuty: boolean;
-	showLoadingScreen: boolean;
-	showInterface: boolean;
-}
+import type { PlayerData } from "@/interfaces/IPlayerData";
+import { fetchNui } from "@/utils/fetchNui";
+import { debugError } from "@/utils/debug";
+import { TIMING } from "@/constants/index";
+import { NUI_EVENTS } from "@/constants/nuiEvents";
+import type { AuthUpdateData, JobType } from "@/interfaces/IUser";
 
 export interface PlayerInfo {
 	rank: string;
@@ -43,7 +31,7 @@ export const MOCK_AUTH_DATA: AuthUpdateData = {
 	onDuty: true,
 	permissions: [],
 	isBoss: true,
-	jobType: 'leo',
+	jobType: "leo",
 };
 
 /** Creates the authentication service */
@@ -58,8 +46,9 @@ export function createAuthService() {
 	let showInterface = $state(false);
 	let permissions = $state<string[]>([]);
 	let isBoss = $state(false);
-	let jobType = $state<JobType>('leo');
+	let jobType = $state<JobType>("leo");
 	let isCivilian = $state(false);
+	let isLoadingPermissions = $state(false);
 
 	const playerInfo = $derived((): PlayerInfo => {
 		if (!playerData) {
@@ -105,7 +94,7 @@ export function createAuthService() {
 		isAuthorized = data.authorized || false;
 		permissions = data.permissions || [];
 		isBoss = data.isBoss || false;
-		jobType = data.jobType || 'leo';
+		jobType = data.jobType || "leo";
 		isCivilian = data.isCivilian || false;
 
 		// Civilians are always authorized for their limited view
@@ -201,17 +190,26 @@ export function createAuthService() {
 			}, TIMING.offDutyLoadingDuration);
 		}
 
-		// Load permissions and color config after auth succeeds
-		if (isAuthorized && onDuty) {
+		if (
+			isAuthorized &&
+			onDuty &&
+			!isLoadingPermissions &&
+			permissions.length === 0
+		) {
 			loadPermissions();
-			loadColorConfig();
 		}
 	}
 
 	/** Fetches the current player's permissions from the server */
-	async function loadPermissions(): Promise<void> {
+	async function loadPermissions(force = false): Promise<void> {
+		if (isLoadingPermissions || (!force && permissions.length > 0)) return;
+
 		try {
-			const response = await fetchNui<{ permissions?: string[]; isBoss?: boolean }>(
+			isLoadingPermissions = true;
+			const response = await fetchNui<{
+				permissions?: string[];
+				isBoss?: boolean;
+			}>(
 				NUI_EVENTS.AUTH.GET_MY_PERMISSIONS,
 				{},
 				{ permissions: [], isBoss: true },
@@ -220,30 +218,10 @@ export function createAuthService() {
 			isBoss = response?.isBoss || false;
 		} catch (error) {
 			debugError("Failed to load permissions:", error);
-			// On failure, default to no permissions (safe)
 			permissions = [];
 			isBoss = false;
-		}
-	}
-
-	/** Loads department color config and applies CSS variable overrides */
-	async function loadColorConfig(): Promise<void> {
-		try {
-			const config = await fetchNui<{ accent?: string; accentText?: string; background?: string; cardBackground?: string; buttonPrimary?: string } | null>(
-				NUI_EVENTS.SETTINGS.GET_COLOR_CONFIG,
-				{},
-				null,
-			);
-			if (config && config.accent) {
-				const root = document.documentElement;
-				root.style.setProperty("--accent-rgb", config.accent);
-				if (config.accentText) root.style.setProperty("--accent-text-rgb", config.accentText);
-				if (config.background) root.style.setProperty("--dark-bg", `rgb(${config.background})`);
-				if (config.cardBackground) root.style.setProperty("--card-dark-bg", `rgb(${config.cardBackground})`);
-				if (config.buttonPrimary) root.style.setProperty("--btn-primary", `rgb(${config.buttonPrimary})`);
-			}
-		} catch {
-			// Non-critical - default CSS variables will apply
+		} finally {
+			isLoadingPermissions = false;
 		}
 	}
 
@@ -323,6 +301,9 @@ export function createAuthService() {
 		get playerInfo() {
 			return playerInfo;
 		},
+		get isLoadingPermissions() {
+			return isLoadingPermissions;
+		},
 		get permissions() {
 			return permissions;
 		},
@@ -342,9 +323,6 @@ export function createAuthService() {
 
 		/** Performs initial authentication check with server */
 		checkAuth,
-
-		/** Handles auth completion and updates UI state */
-		handleAuthComplete,
 
 		/** Sends request to go on duty */
 		goOnDuty,
@@ -376,6 +354,7 @@ export interface AuthService {
 	readonly showLoadingScreen: boolean;
 	readonly showInterface: boolean;
 	readonly playerInfo: () => PlayerInfo;
+	readonly isLoadingPermissions: boolean;
 	readonly permissions: string[];
 	readonly isBoss: boolean;
 	readonly jobType: JobType;
@@ -392,5 +371,3 @@ export interface AuthService {
 	hasAnyPermission: (...perms: string[]) => boolean;
 	hasRawPermission: (perm: string) => boolean;
 }
-
-export type AuthServiceType = ReturnType<typeof createAuthService>;

--- a/web/src/services/settingsService.svelte.ts
+++ b/web/src/services/settingsService.svelte.ts
@@ -1,0 +1,75 @@
+import { fetchNui } from "@/utils/fetchNui";
+import { NUI_EVENTS } from "@/constants/nuiEvents";
+import { debugError } from "@/utils/debug";
+
+export interface ColorConfig {
+	accent: string;
+	accentText: string;
+	background: string;
+	cardBackground: string;
+	buttonPrimary: string;
+}
+
+export function createSettingsService() {
+	let colorConfig = $state<ColorConfig | null>(null);
+	let isLoading = $state(false);
+	let error = $state<string | null>(null);
+
+	function applyThemeColors(config: ColorConfig) {
+		const root = document.documentElement;
+		if (config.accent)
+			root.style.setProperty("--accent-rgb", config.accent);
+		if (config.accentText)
+			root.style.setProperty("--accent-text-rgb", config.accentText);
+		if (config.background)
+			root.style.setProperty("-dark-bg", config.background);
+		if (config.cardBackground)
+			root.style.setProperty("--card-dark-bg", config.cardBackground);
+		if (config.buttonPrimary)
+			root.style.setProperty("--btn-primary", config.buttonPrimary);
+	}
+
+	async function loadColorConfig(): Promise<void> {
+		if (isLoading) return;
+		try {
+			isLoading = true;
+			error = null;
+			const config = await fetchNui<ColorConfig | null>(
+				NUI_EVENTS.SETTINGS.GET_COLOR_CONFIG,
+				{},
+				null,
+			);
+
+			if (config && config.accent) {
+				colorConfig = config;
+				applyThemeColors(config);
+			}
+		} catch (err) {
+			error = "Failed to load color config";
+			debugError("Failed to load color config:", err);
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	function setColorConfig(config: ColorConfig): void {
+		colorConfig = config;
+		applyThemeColors(config);
+	}
+
+	return {
+		get colorConfig() {
+			return colorConfig;
+		},
+		get isLoading() {
+			return isLoading;
+		},
+		get error() {
+			return error;
+		},
+		loadColorConfig,
+		setColorConfig,
+	};
+}
+
+export const settingsService = createSettingsService();


### PR DESCRIPTION
## Changes summary:

- Introduced `settingsService` for central settings configuration (only colours currently).
- Changed `authService` to delegate color configuration to `settingsService`.

This solves an issue where previously multiple fetchNui requests were sent for `getColorConfig` and `getMyPermissions` callbacks at nearly the same time causing some to timeout.

P.S. Will probably move more/all settings-related things into the central settings service, just haven't got around to it yet.