### PR TITLE
fix(utils): stop returning mockData on timeout

### DIFF
--- a/web/src/utils/fetchNui.ts
+++ b/web/src/utils/fetchNui.ts
@@ -1,7 +1,7 @@
 import { isEnvBrowser } from "./misc";
 import { GetParentResourceName } from "./fivem";
-import type { NuiEventName } from "../constants/nuiEvents";
-import { validateNuiAction } from "../security/nuiSecurity";
+import type { NuiEventName } from "@/constants/nuiEvents";
+import { validateNuiAction } from "@/security/nuiSecurity";
 
 const DEFAULT_TIMEOUT = 10000; // 10 seconds
 
@@ -20,22 +20,9 @@ export async function fetchNui<T = any>(
 		return {} as T;
 	}
 
-	const options = {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json; charset=UTF-8",
-		},
-		body: JSON.stringify(data),
-	};
-
 	if (isEnvBrowser()) {
-		if (mockData) {
-			return new Promise((resolve) => {
-				setTimeout(() => resolve(mockData), 100);
-			});
-		}
 		return new Promise((resolve) => {
-			setTimeout(() => resolve({} as T), 100);
+			setTimeout(() => resolve(mockData || ({} as T)), 100);
 		});
 	}
 
@@ -46,10 +33,14 @@ export async function fetchNui<T = any>(
 		const controller = new AbortController();
 		const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-		const resp = await fetch(
-			`https://${resourceName}/${eventName}`,
-			{ ...options, signal: controller.signal },
-		);
+		const resp = await fetch(`https://${resourceName}/${eventName}`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json; charset=UTF-8",
+			},
+			body: JSON.stringify(data),
+			signal: controller.signal,
+		});
 		clearTimeout(timeoutId);
 
 		if (resp.ok) {
@@ -58,11 +49,11 @@ export async function fetchNui<T = any>(
 
 		throw new Error(`HTTP error! status: ${resp.status}`);
 	} catch (err) {
-		if (isEnvBrowser() && mockData !== undefined) {
-			return mockData;
-		}
 		if (err instanceof DOMException && err.name === "AbortError") {
-			console.warn(`[ps-mdt] fetchNui timed out after ${timeout}ms:`, eventName);
+			console.warn(
+				`[ps-mdt] fetchNui timed out after ${timeout}ms:`,
+				eventName,
+			);
 			return {} as T;
 		}
 		throw err;

--- a/web/src/utils/fetchNui.ts
+++ b/web/src/utils/fetchNui.ts
@@ -58,7 +58,7 @@ export async function fetchNui<T = any>(
 
 		throw new Error(`HTTP error! status: ${resp.status}`);
 	} catch (err) {
-		if (mockData !== undefined) {
+		if (isEnvBrowser() && mockData !== undefined) {
 			return mockData;
 		}
 		if (err instanceof DOMException && err.name === "AbortError") {


### PR DESCRIPTION
## Changes summary:

- Updated `fetchNui` to never return mockData from the `catch` block.
- This doesn't resolve `fetchNui` timing out. (Solved in #540).

`mockData` still gets returned when `isEnvBrowser` is true, but it's handled in the main `try` block instead of when a request times out and is caught. This prevents unwanted behaviour like a permission bypass if `mockData` contains `{ isBoss: true }` e.g. https://github.com/Project-Sloth/ps-mdt/blob/6bc7b406152cbcf30f84b1b05b9fe47123a51c47/web/src/services/authService.svelte.ts#L211-L227