### PR TITLE
Sync citizen license changes to QBCore in-memory player state

### DIFF
--- a/server/backend/citizens.lua
+++ b/server/backend/citizens.lua
@@ -635,6 +635,16 @@ ps.registerCallback(resourceName .. ':server:updateCitizenLicense', function(sou
     metadata.licences[licenseType] = enabled
 
     MySQL.update.await('UPDATE players SET metadata = ? WHERE citizenid = ?', { json.encode(metadata), citizenId })
+
+    -- Sync to QBCore in-memory player data if the target is currently online
+    if exports['qb-core'] then
+        local QBCore = exports['qb-core']:GetCoreObject()
+        local onlinePlayer = QBCore.Functions.GetPlayerByCitizenId(citizenId)
+        if onlinePlayer then
+            onlinePlayer.Functions.SetMetaData('licences', metadata.licences)
+        end
+    end
+
     return { success = true }
 end)
 


### PR DESCRIPTION
**Problem**: updateCitizenLicense updates the players table in MySQL but never calls Player.Functions.SetMetaData. If the target citizen is online, QBCore's cached PlayerData.metadata.licences stays stale until they relog. Any resource reading live player data (e.g. shop license checks) sees the old state and behaves as if the license was never granted.

**Fix**: After the DB write, resolve the player via QBCore.Functions.GetPlayerByCitizenId and call SetMetaData('licences', ...) if they're online. Offline players are unaffected, their metadata is loaded fresh from the DB on next login.