### PR TITLE
feat: mdt weapon tags improvments

### DIFF
--- a/client/backend/weapons.lua
+++ b/client/backend/weapons.lua
@@ -14,6 +14,12 @@ RegisterNUICallback('getWeaponBolos', function(data, cb)
     cb(result)
 end)
 
+RegisterNUICallback('saveWeaponFlags', function(data, cb)
+    local flags = type(data.flags) == 'table' and data.flags or json.decode(data.flags) or {}
+    local result = ps.callback(resourceName .. ':server:saveWeaponFlags', data.serial, flags)
+    cb(result or { success = false })
+end)
+
 RegisterNUICallback('getWeaponOwnershipHistory', function(data, cb)
     if not MDTOpen then cb({}) return end
     if not data or not data.serial then

--- a/server/backend/weapons.lua
+++ b/server/backend/weapons.lua
@@ -141,6 +141,7 @@ ps.registerCallback('ps-mdt:server:getWeapons', function(source)
             name = (QBCore and QBCore.Shared and QBCore.Shared.Weapons and QBCore.Shared.Weapons[GetHashKey(v.weaponModel)] and QBCore.Shared.Weapons[GetHashKey(v.weaponModel)].label) or v.weaponModel,
             image = 'https://docs.fivem.net/weapons/' .. v.weaponModel:upper() .. '.png',
             type = class[modelLower] and class[modelLower].type or 'unknown',
+            flags = v.flags and json.decode(v.flags) or {},
         }
         table.insert(newData, weaponInfo)
     end
@@ -172,6 +173,30 @@ ps.registerCallback(resourceName .. ':server:getWeaponOwnershipHistory', functio
         ORDER BY created_at DESC
     ]], { serial })
     return rows or {}
+end)
+
+ps.registerCallback(resourceName .. ':server:saveWeaponFlags', function(source, serial, flags)
+    local src = source
+    if not CheckAuth(src) then return { success = false } end
+    if not serial or serial == '' then return { success = false } end
+
+    local decoded
+    if type(flags) == 'table' then
+        decoded = flags
+    elseif type(flags) == 'string' then
+        decoded = json.decode(flags) or {}
+    else
+        decoded = {}
+    end
+
+    local encoded = json.encode(decoded)
+    local affected = MySQL.update.await('UPDATE mdt_weapons SET flags = ? WHERE serial = ?', { encoded, serial })
+
+    if affected and affected > 0 then
+        return { success = true }
+    else
+        return { success = false, message = 'Database error' }
+    end
 end)
 
 -- Save/Edit Weapon Info (from NUI)

--- a/sql/qbcore.sql
+++ b/sql/qbcore.sql
@@ -566,6 +566,7 @@ CREATE TABLE IF NOT EXISTS `mdt_weapons` (
   `information` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
   `weaponClass` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
   `weaponModel` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `flags` JSON DEFAULT NULL,
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE KEY `unique_serial` (`serial`),
   KEY `FK_mdt_weapons_mdt_profiles` (`owner`),

--- a/sql/qbx.sql
+++ b/sql/qbx.sql
@@ -566,6 +566,7 @@ CREATE TABLE IF NOT EXISTS `mdt_weapons` (
   `information` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `weaponClass` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `weaponModel` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `flags` JSON DEFAULT NULL,
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE KEY `unique_serial` (`serial`),
   KEY `FK_mdt_weapons_mdt_profiles` (`owner`),

--- a/web/src/constants/nuiEvents.ts
+++ b/web/src/constants/nuiEvents.ts
@@ -97,6 +97,7 @@ export const NUI_EVENTS = {
 		GET_WEAPON: "getWeapon",
 		GET_WEAPON_HISTORY: "getWeaponOwnershipHistory",
 		UPDATE_WEAPON: "updateWeapon",
+		SAVE_WEAPON_FLAGS: "saveWeaponFlags",
 	},
 	CHARGE: {
 		GET_CHARGES: "getCharges",

--- a/web/src/pages/Weapons.svelte
+++ b/web/src/pages/Weapons.svelte
@@ -6,6 +6,11 @@
 	import { globalNotifications } from "../services/notificationService.svelte";
 	import Pagination from "../components/Pagination.svelte";
 
+	interface WeaponFlag {
+		type: string;
+		info: string;
+	}
+
 	interface Weapon {
 		id: number;
 		serial: string;
@@ -18,7 +23,7 @@
 		image: string;
 		type: string;
 		seenIn: number;
-		flags: string[];
+		flags: WeaponFlag[];
 		tint: string;
 	}
 
@@ -41,6 +46,13 @@
 	let weaponHistory = $state<WeaponHistoryEntry[]>([]);
 	let historyLoading = $state(false);
 
+	let newFlag = $state({ type: "", info: "" });
+	const PRESET_FLAGS = ["Stolen", "Wanted"];
+	
+	const FLAG_TEMPLATES: Record<string, string> = {
+		"Stolen": "Reported stolen on [DATE] by [NAME].",
+		"Wanted": "Wanted in connection with [CASE/REASON] as of [DATE].",
+	};
 	let weaponPage = $state(1);
 	let weaponPerPage = $state(25);
 
@@ -66,14 +78,15 @@
 		weaponPage = 1;
 	});
 
-	function getFlagClass(flag: string): string {
-		switch (flag) {
-			case "Active Warrant":
-			case "Dangerous":
+	function onFlagTypeChange() {
+		newFlag.info = FLAG_TEMPLATES[newFlag.type] ?? "";
+	}
+
+	function getFlagClass(flag: WeaponFlag): string {
+		switch (flag.type) {
+			case "Stolen":
+			case "Wanted":
 				return "pill pill-red";
-			case "Bolo":
-			case "Flight Risk":
-				return "pill pill-orange";
 			default:
 				return "pill pill-grey";
 		}
@@ -106,7 +119,55 @@
 		}
 	}
 
+	async function addFlag() {
+		if (!newFlag.type || !selectedWeapon) return;
+
+		const currentFlags = selectedWeapon.flags ?? [];
+		if (currentFlags.some(f => f.type === newFlag.type)) return;
+
+		const updated = [...currentFlags, { type: newFlag.type, info: newFlag.info.trim() }];
+
+		if (isEnvBrowser()) {
+			selectedWeapon = { ...selectedWeapon, flags: updated };
+			newFlag = { type: "", info: "" };
+			return;
+		}
+
+		const response = await fetchNui<{ success: boolean }>(
+			NUI_EVENTS.WEAPON.SAVE_WEAPON_FLAGS,
+			{ serial: selectedWeapon.serial, flags: updated },
+		);
+		if (response?.success) {
+			selectedWeapon = { ...selectedWeapon, flags: updated };
+			newFlag = { type: "", info: "" };
+		} else {
+			globalNotifications.error("Failed to save flag");
+		}
+	}
+
+	async function removeFlag(type: string) {
+		if (!selectedWeapon) return;
+		const currentFlags = selectedWeapon.flags ?? [];
+		const updated = currentFlags.filter(f => f.type !== type);
+
+		if (isEnvBrowser()) {
+			selectedWeapon = { ...selectedWeapon, flags: updated };
+			return;
+		}
+
+		const response = await fetchNui<{ success: boolean }>(
+			NUI_EVENTS.WEAPON.SAVE_WEAPON_FLAGS,
+			{ serial: selectedWeapon.serial, flags: updated },
+		);
+		if (response?.success) {
+			selectedWeapon = { ...selectedWeapon, flags: updated };
+		} else {
+			globalNotifications.error("Failed to remove flag");
+		}
+	}
+
 	function closeWeapon() {
+		refreshWeapons()
 		selectedWeapon = null;
 		weaponHistory = [];
 	}
@@ -114,10 +175,10 @@
 	onMount(async () => {
 		if (isEnvBrowser()) {
 			weapons = [
-				{ id: 1, serial: 'WPN-48291', scratched: false, owner: 'Marcus Johnson', information: 'Registered service weapon', weaponClass: 'Pistol', weaponModel: 'WEAPON_PISTOL', name: 'Pistol', image: '', type: 'Handgun', seenIn: 3, flags: [], tint: 'Default' },
-				{ id: 2, serial: 'WPN-73820', scratched: true, owner: 'Unknown', information: 'Serial scratched off - found at crime scene', weaponClass: 'SMG', weaponModel: 'WEAPON_SMG', name: 'SMG', image: '', type: 'Submachine Gun', seenIn: 1, flags: ['Dangerous'], tint: 'Army' },
+				{ id: 1, serial: 'WPN-48291', scratched: false, owner: 'Marcus Johnson', information: 'Registered service weapon', weaponClass: 'Pistol', weaponModel: 'WEAPON_PISTOL', name: 'Pistol', image: '', type: 'Handgun', seenIn: 3, flags: [{ type: "Stolen", info: "reported Stolen" }], tint: 'Default' },
+				{ id: 2, serial: 'WPN-73820', scratched: true, owner: 'Unknown', information: 'Serial scratched off - found at crime scene', weaponClass: 'SMG', weaponModel: 'WEAPON_SMG', name: 'SMG', image: '', type: 'Submachine Gun', seenIn: 1, flags: [{ type: "Stolen", info: "reported Stolen" }], tint: 'Army' },
 				{ id: 3, serial: 'WPN-55194', scratched: false, owner: 'Sarah Williams', information: 'Licensed for personal protection', weaponClass: 'Pistol', weaponModel: 'WEAPON_COMBATPISTOL', name: 'Combat Pistol', image: '', type: 'Handgun', seenIn: 0, flags: [], tint: 'Default' },
-				{ id: 4, serial: 'WPN-10477', scratched: false, owner: 'David Chen', information: 'Hunting rifle, valid license', weaponClass: 'Rifle', weaponModel: 'WEAPON_MUSKET', name: 'Musket', image: '', type: 'Rifle', seenIn: 2, flags: ['Bolo'], tint: 'Default' },
+				{ id: 4, serial: 'WPN-10477', scratched: false, owner: 'David Chen', information: 'Hunting rifle, valid license', weaponClass: 'Rifle', weaponModel: 'WEAPON_MUSKET', name: 'Musket', image: '', type: 'Rifle', seenIn: 2, flags: [{ type: "Wanted", info: "Found Bullets - Report #1337" }], tint: 'Default' },
 			];
 			loading = false;
 			return;
@@ -164,7 +225,7 @@
 					<span class="pill pill-red">Scratched</span>
 				{/if}
 				{#each selectedWeapon.flags as flag}
-					<span class={getFlagClass(flag)}>{flag}</span>
+					<span class={getFlagClass(flag)}>{flag.type}</span>
 				{/each}
 			</div>
 		</div>
@@ -202,16 +263,45 @@
 				</div>
 			{/if}
 
-			{#if selectedWeapon.flags && selectedWeapon.flags.length}
-				<div class="section">
-					<div class="section-title">Flags</div>
-					<div class="flags-row">
+			<div class="section">
+				<div class="section-title">Flags</div>
+
+				{#if selectedWeapon.flags?.length}
+					<div class="flags-row" style="margin-bottom: 8px;">
 						{#each selectedWeapon.flags as flag}
-							<span class={getFlagClass(flag)}>{flag}</span>
+							<span class={getFlagClass(flag)} style="display:inline-flex;align-items:center;gap:6px;">
+								<span>{flag.type}</span>
+								{#if flag.info}
+									<span style="opacity:0.6;font-weight:400;">— {flag.info}</span>
+								{/if}
+								<button class="tag-remove" onclick={() => removeFlag(flag.type)} aria-label="Remove flag">
+									<svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+								</button>
+							</span>
 						{/each}
 					</div>
+				{/if}
+
+				<div class="flag-add-row">
+					<select class="form-select" bind:value={newFlag.type} onchange={onFlagTypeChange}>
+						<option value="">-- Select --</option>
+						{#each PRESET_FLAGS as preset}
+							<option value={preset} disabled={selectedWeapon.flags?.some(f => f.type === preset)}>
+								{preset}
+							</option>
+						{/each}
+					</select>
+					<input
+						class="form-input"
+						bind:value={newFlag.info}
+						placeholder="Additional info..."
+						onkeydown={(e) => { if (e.key === 'Enter') addFlag(); }}
+					/>
+					<button class="add-tag-btn" onclick={addFlag} disabled={!newFlag.type.trim()}>
+						+ Add
+					</button>
 				</div>
-			{/if}
+			</div>
 
 			<div class="section">
 				<div class="section-title">Ownership History</div>
@@ -284,8 +374,8 @@
 							<span class="col-type">{weapon.type}</span>
 							<span class="col-tint">{weapon.tint || 'Default'}</span>
 							<span class="col-flags">
-								{#each weapon.flags as flag}
-									<span class={getFlagClass(flag)}>{flag}</span>
+								{#each weapon.flags || [] as flag}
+									<span class={getFlagClass(flag)}>{flag.type}</span>
 								{/each}
 							</span>
 						</button>
@@ -693,10 +783,96 @@
 		padding: 16px;
 	}
 
+	/* ===== Tags/Flags ===== */
 	.flags-row {
 		display: flex;
 		gap: 4px;
 		flex-wrap: wrap;
+	}
+
+	.tag-remove {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: transparent;
+		border: none;
+		color: inherit;
+		opacity: 0.4;
+		cursor: pointer;
+		padding: 0;
+		transition: opacity 0.1s;
+		line-height: 1;
+	}
+
+	.tag-remove:hover {
+		opacity: 1;
+	}
+
+	.flag-add-row {
+		display: flex;
+		gap: 6px;
+		align-items: center;
+		margin-top: 8px;
+	}
+
+	.flag-add-row .form-select {
+		width: 120px;
+		flex-shrink: 0;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(255, 255, 255, 0.06);
+		border-radius: 3px;
+		padding: 5px 8px;
+		color: rgba(255, 255, 255, 0.8);
+		font-size: 10px;
+		font-family: inherit;
+	}
+
+	.flag-add-row .form-select:focus {
+		outline: none;
+		border-color: rgba(255, 255, 255, 0.1);
+	}
+
+	.flag-add-row .form-input {
+		flex: 1;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(255, 255, 255, 0.06);
+		border-radius: 3px;
+		padding: 5px 8px;
+		color: rgba(255, 255, 255, 0.8);
+		font-size: 11px;
+		font-family: inherit;
+	}
+
+	.flag-add-row .form-input:focus {
+		outline: none;
+		border-color: rgba(255, 255, 255, 0.1);
+	}
+
+	.flag-add-row .form-input::placeholder {
+		color: rgba(255, 255, 255, 0.2);
+	}
+
+	.add-tag-btn {
+		background: rgba(16, 185, 129, 0.06);
+		color: rgba(52, 211, 153, 0.7);
+		border: 1px solid rgba(16, 185, 129, 0.1);
+		border-radius: 3px;
+		padding: 4px 10px;
+		font-size: 10px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.1s;
+		white-space: nowrap;
+	}
+
+	.add-tag-btn:hover:not(:disabled) {
+		background: rgba(16, 185, 129, 0.12);
+		color: rgba(110, 231, 183, 0.9);
+	}
+
+	.add-tag-btn:disabled {
+		opacity: 0.3;
+		cursor: not-allowed;
 	}
 
 	/* ===== History ===== */


### PR DESCRIPTION
# Weapon Flags System

## Overview
This PR introduces a dynamic flag system for weapons in the MDT, replacing the previous static display with a fully interactive add/remove interface. Flags now support structured data (type + info), preset quick-select options, and free-text custom input.

[Showcase Video](https://medal.tv/de/games/gta-v/clips/mB9uGpT1ZW8dqVn3H?invite=cr-MSw5SFIsNjU4NTA3MTU&v=41)
---

## Database

- Added `flags` column (`JSON DEFAULT NULL`) to the `mdt_weapons` table

- Add this into database ( if already inserted sql ):
```ALTER TABLE `mdt_weapons` ADD COLUMN `flags` JSON DEFAULT NULL;```

- Stores flags as a JSON array of objects: `[{ "type": "Stolen", "info": "Reported stolen on ..." }]`

---

## Backend (Lua)

- Added `ps-mdt:server:saveWeaponFlags` callback to persist flag changes to the database
- Updated `ps-mdt:server:getWeapons` to decode and return the `flags` JSON column as a Lua table
- Added `RegisterNUICallback('saveWeaponFlags', ...)` on the client to bridge NUI → server

---

## Frontend (Svelte)

### Weapon Interface
- Extended the `Weapon` interface: `flags` is now `WeaponFlag[]` instead of `string[]`
- Added `WeaponFlag` interface: `{ type: string; info: string }`

### Flag Management
- Added `addFlag(flag?)` and `removeFlag(type)` functions that save changes via `NUI_EVENTS.WEAPON.SAVE_WEAPON_FLAGS`
- Flags are safely handled with `?? []` fallback to prevent null/undefined errors

### Preset Flags
- Defined `PRESET_FLAGS = ["Stolen", "Wanted"]` as the only recognized preset flags
- Added `FLAG_TEMPLATES` for automatic info prefill when selecting a preset:
  - **Stolen:** `"Reported stolen on [DATE] by [NAME]."`
  - **Wanted:** `"Wanted in connection with [CASE/REASON] as of [DATE]."`
- Selecting a preset auto-populates the info field via `onFlagTypeChange()`

### UI — Flags Section (Detail View)
- Flags section is always visible in the weapon detail view (even when empty) so flags can be added
- Active flags are displayed as removable pills with an inline × button
- Dropdown to select preset flag type + text input for additional info + Add button
- Flags already applied are disabled in the dropdown to prevent duplicates

### `getFlagClass`
- Updated to accept `WeaponFlag` instead of `string`
- Only maps the two active presets:
  - `Stolen` / `Wanted` → `pill-red`
  - Everything else → `pill-grey`

### Styling
- Flags section styling aligned with the Vehicles page for visual consistency
- Add button uses the same green accent as other save/confirm actions in the MDT

---

## NUI Events
- Added `SAVE_WEAPON_FLAGS` to `NUI_EVENTS.WEAPON`