### PR TITLE
Fixed issue with offset / not properly calibrated for gta -> leaflet …

### DIFF
--- a/web/src/pages/Map.svelte
+++ b/web/src/pages/Map.svelte
@@ -495,10 +495,10 @@
     const offsetY = 31;
 
     function toMapLatLng(coords: { x: number; y: number }) {
-        return [coords.y - offsetY, coords.x + offsetX];
+        return [coords.y, coords.x];
     }
     function toGtaCoords(latlng: L.LatLng): GtaPoint {
-        return { x: latlng.lng - offsetX, y: latlng.lat + offsetY };
+        return { x: latlng.lng, y: latlng.lat };
     }
 
     // ── Zone rendering ────────────────────────────────────────────────────────
@@ -1337,7 +1337,7 @@
                 const dy = pos2.lat - pos1.lat;
                 return Math.sqrt(dx * dx + dy * dy);
             },
-            transformation: new Transformation(0.02072, 117.3, -0.0205, 172.8),
+            transformation: new Transformation(0.02061188, 117.41909, -0.02059566, 172.62816),
             infinite: false,
         });
     }


### PR DESCRIPTION
Fixes the issue with the offset of markers vs. real world pos by applying new transformation and removing offset completely.
Accuracy seems pretty good now:

<img width="1621" height="853" alt="imagem" src="https://github.com/user-attachments/assets/16be7586-6638-49b6-b01f-be1579e62a4f" />
<img width="1530" height="890" alt="imagem" src="https://github.com/user-attachments/assets/678d274e-12db-4b9e-94be-cd131d3f56b4" />

