### PR TITLE
fix(ci/workflow): remove string regex matching for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,62 +1,51 @@
 name: Release
-
 on:
   push:
     tags:
-      - 'v*'
-
+      - '*[0-9]*'
 permissions:
   contents: write
-
 jobs:
   release:
     name: Build and publish release
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Resolve version
         id: version
         run: |
           TAG_NAME="${GITHUB_REF_NAME}"
+          # Strip a leading "v" if present (v3.1.2 -> 3.1.2, 3.1.2 stays 3.1.2)
           VERSION="${TAG_NAME#v}"
           echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Releasing tag '${TAG_NAME}' (version '${VERSION}')"
-
       - name: Sync fxmanifest.lua version
         run: |
           sed -i -E "s/^(version[[:space:]]+')[^']*(')/\1${{ steps.version.outputs.version }}\2/" fxmanifest.lua
           grep -E "^version " fxmanifest.lua
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
-
       - name: Install web dependencies
         working-directory: web
         run: pnpm install --no-frozen-lockfile
-
       - name: Build web frontend
         working-directory: web
         run: pnpm run build
-
       - name: Stage release files
         run: |
           STAGE_DIR="release-stage/ps-mdt"
           mkdir -p "${STAGE_DIR}"
-
           cp -r client       "${STAGE_DIR}/"
           cp -r server       "${STAGE_DIR}/"
           cp -r sql          "${STAGE_DIR}/"
@@ -66,13 +55,10 @@ jobs:
           cp    LICENSE      "${STAGE_DIR}/"
           cp    README.md    "${STAGE_DIR}/"
           cp    SECURITY.md  "${STAGE_DIR}/"
-
           mkdir -p "${STAGE_DIR}/web"
           cp -r web/dist "${STAGE_DIR}/web/dist"
-
           echo "Staged contents:"
           find "${STAGE_DIR}" -maxdepth 3 -print
-
       - name: Create release archive
         id: archive
         run: |
@@ -80,7 +66,6 @@ jobs:
           (cd release-stage && zip -r "../${ARCHIVE_NAME}" ps-mdt)
           echo "name=${ARCHIVE_NAME}" >> "$GITHUB_OUTPUT"
           ls -lh "${ARCHIVE_NAME}"
-
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,4 +74,5 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(steps.version.outputs.tag, '-') }}
+          make_latest: true
           files: ${{ steps.archive.outputs.name }}


### PR DESCRIPTION
Originally, this was implemented without the thought of how tags were being used so tags required a v* to be apart of the tag to do the auto-release. This removes that so as long as it has numerics in it, it will create a release and set it to the latest