### PR TITLE
fix(roster): require CheckAuth on getRosterList callback

### DIFF
--- a/server/backend/roster.lua
+++ b/server/backend/roster.lua
@@ -131,6 +131,8 @@ local function checkDuty(citizenid, matchFn)
 end
 
 ps.registerCallback('ps-mdt:server:getRosterList', function(source)
+    local src = source
+    if not CheckAuth(src) then return {} end
     -- Scope the roster to the caller's domain: EMS sees EMS, police sees police.
     local domain = GetMdtDomain(source)
     local jobList, matchFn, defaultDept, scopeJobType


### PR DESCRIPTION
Adds the missing auth check to getRosterList, matching the pattern already used by every other callback in this file (getOfficerTags, promoteOfficer, ireOfficer, updateOfficerCallsign). Without it, any player can pull the full roster (names, citizenids, callsigns, ranks, certifications and live radio channels) regardless of MDT access.

Refs #566